### PR TITLE
Changed from ssh to https.

### DIFF
--- a/airsea/meta.yaml
+++ b/airsea/meta.yaml
@@ -3,26 +3,10 @@ package:
   version: !!str 0.0.1_DEV
 
 source:
-  git_url: git@github.com:ocefpaf/python-airsea.git
-#  patches:
-   # List any patch files here
-   # - fix.patch
+    git_url: https://github.com/ocefpaf/python-airsea.git
 
 build:
   number: 0
-  #preserve_egg_dir: True
-  #entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    # - seawater = seawater:main
-    #
-    # Would create an entry point called seawater that calls seawater.main()
-
-
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
 
 requirements:
   build:
@@ -39,23 +23,7 @@ test:
   imports:
     - airsea
 
-  #commands:
-    # You can put test commands to be run here.  Use this to test that the
-    # entry points work.
-
-
-  # You can also put a file called run_test.py in the recipe that will be run
-  # at test time.
-
-  # requires:
-    # Put any additional test requirements here.  For example
-    # - nose
-
 about:
   home: http://github.com/ocefpaf/python-airsea
   license: MIT License
   summary: 'Airsea Library for Python'
-
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml

--- a/geolinks/meta.yaml
+++ b/geolinks/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: !!str 0.1
 
 source:
-  git_url: git@github.com:geopython/geolinks.git
+  git_url: https://github.com/geopython/geolinks.git
 #  patches:
    # List any patch files here
    # - fix.patch

--- a/octant/meta.yaml
+++ b/octant/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: !!str 0.8_DEV
 
 source:
-  git_url: git@github.com:hetland/octant.git
+  git_url: https://github.com/hetland/octant.git
 #  patches:
    # List any patch files here
    # - fix.patch

--- a/pycsw/meta.yaml
+++ b/pycsw/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: !!str 1.10.1
 
 source:
-  git_url: git@github.com:geopython/pycsw.git
+  git_url: https://github.com/geopython/pycsw.git
 # git_tag: 1.10.1
 #  patches:
    # List any patch files here

--- a/rasterio/meta.yaml
+++ b/rasterio/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: !!str 0.15
 
 source:
-  git_url: git@github.com:mapbox/rasterio.git
+  git_url: https://github.com/mapbox/rasterio.git
 #  patches:
    # List any patch files here
    # - fix.patch

--- a/thredds_crawler/meta.yaml
+++ b/thredds_crawler/meta.yaml
@@ -6,7 +6,7 @@ source:
 # fn: thredds_crawler-0.6.tar.gz
 # url: https://pypi.python.org/packages/source/t/thredds_crawler/thredds_crawler-0.6.tar.gz
 # md5: fd75a6446b6c0f0cab9e6eccc24a409f
-  git_url: git@github.com:asascience-open/thredds_crawler.git
+  git_url: https://github.com/asascience-open/thredds_crawler.git
 #  patches:
    # List any patch files here
    # - fix.patch

--- a/udunitspy/meta.yaml
+++ b/udunitspy/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: !!str 0.0.6
 
 source:
-  git_url: git@github.com:blazetopher/udunitspy.git
+  git_url: https://github.com/blazetopher/udunitspy.git
 # fn: udunitspy-0.0.6.tar.gz
 # url: https://pypi.python.org/packages/source/u/udunitspy/udunitspy-0.0.6.tar.gz
 # md5: 49a7520202e7e36fcbc6767b36e07ac2


### PR DESCRIPTION
Using https we do not need a password nor a ssh key to build packages.  This is required to build packages using the new binstar build VM.