### PR TITLE
Revert submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "conda-recipes-scitools"]
-	path = conda-recipes-scitools
-	url = https://github.com/SciTools/conda-recipes-scitools.git

--- a/biggus/build.sh
+++ b/biggus/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/biggus/meta.yaml
+++ b/biggus/meta.yaml
@@ -1,0 +1,21 @@
+package:
+    name: biggus
+    version: "0.7.0"
+
+source:
+    git_url: https://github.com/SciTools/biggus.git
+    git_tag: v0.7.0
+
+requirements:
+    build:
+        - python
+        - setuptools
+
+    run:
+        - python
+        - numpy
+
+about:
+    home: https://pypi.python.org/pypi/Biggus
+    license: LGPL
+    summary: Virtual large arrays and lazy evaluation.

--- a/biggus/upload_all.sh
+++ b/biggus/upload_all.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+conda config --set binstar_upload yes
+
+for PY in 27 33 34
+do
+    for NPY in 17 18
+    do
+        export CONDA_PY=$PY
+        export CONDA_NPY=$NPY
+        conda build .
+    done
+done

--- a/cartopy/build.sh
+++ b/cartopy/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+${PYTHON} -sE setup.py install
+

--- a/cartopy/meta.yaml
+++ b/cartopy/meta.yaml
@@ -1,0 +1,49 @@
+package:
+  name: cartopy
+  version: !!str 0.11.2
+source:
+  git_url: https://github.com/SciTools/cartopy.git
+  git_tag: v0.11.2
+
+requirements:
+  build:
+    - python
+    - six
+    - numpy
+    - cython
+    - proj4
+    - geos
+    # On OSX We need to effectively pin the geos version to the
+    # one used by the specific shapely being targetted (we're letting
+    # conda's package solver will deal with that).
+    - shapely ==1.4.3.issue177  # [osx]
+    # owslib is not a build dependency, but it exists as a recipe and
+    # should be built before cartopy for cartopy testing. Obvious-ci
+    # should be extended to resolve this issue in the future.
+    - owslib
+  run:
+    - python
+    - six
+    - mock
+    - nose
+    - pil
+    - owslib
+    - numpy
+    - proj4
+    - shapely ==1.4.3.issue177  # [osx]
+    - shapely                   # [not osx]
+    - scipy
+    - pyshp
+    - matplotlib
+    - pyepsg
+
+test:
+  imports:
+    - cartopy
+    - cartopy.mpl.geoaxes
+
+about:
+  home: http://scitools.org.uk/cartopy
+  license: GNU LGPL
+  summary: 'A library providing cartographic tools for python'
+

--- a/cartopy/run_test.py
+++ b/cartopy/run_test.py
@@ -1,0 +1,9 @@
+import cartopy.crs as ccrs
+
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+
+ax = plt.axes(projection=ccrs.Robinson())
+ax.coastlines()
+plt.savefig('working.png')

--- a/cdat-lite/build.sh
+++ b/cdat-lite/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# CDAT-lite v5.2 finds the HDF5 library by checking for the static version,
+# so we pretend it exists.
+touch $PREFIX/lib/libhdf5.a
+
+# cdat_lite-5.2-1.tar.gz ships with broken symlinks which get in the way
+# of setup.py getting started, so we remove them.
+rm lib/MV2.py
+rm lib/cdat_info.py
+
+export NETCDF_HOME=$PREFIX
+export HDF5_HOME=$PREFIX
+$PYTHON setup.py install --prefix=$PREFIX
+
+# Tidy up the fake static library.
+rm $PREFIX/lib/libhdf5.a

--- a/cdat-lite/meta.yaml
+++ b/cdat-lite/meta.yaml
@@ -1,0 +1,35 @@
+package:
+    name: cdat-lite
+    version: 5.2.1
+
+source:
+    fn: cdat_lite-5.2-1.tar.gz
+    url: http://ndg.nerc.ac.uk/dist/cdat_lite-5.2-1.tar.gz
+    sha1: 8d7f373367cd05c0378d310ce78ee4a1a68d258b
+    patches:
+        - patch.diff  # [osx]
+
+build:
+    number: 2
+
+requirements:
+    build:
+        - python
+        - numpy <1.9  # Depends on oldnumeric, which was removed in 1.9
+        - setuptools
+        - libnetcdf 4.*
+        - hdf5
+    run:
+        - python
+        - numpy <1.9
+        - libnetcdf 4.*
+        - hdf5
+
+test:
+  imports:
+    - cdat_lite
+    - cdtime
+
+about:
+  home: http://proj.badc.rl.ac.uk/cedaservices/wiki/CdatLite
+  summary: A Python package for managing and analysing climate science data.

--- a/cdat-lite/patch.diff
+++ b/cdat-lite/patch.diff
@@ -1,0 +1,10 @@
+--- libcdms/src/cdunif/gamach_orig.c	2014-08-13 07:52:16.000000000 +0100
++++ libcdms/src/cdunif/gamach.c	2014-08-13 07:52:26.000000000 +0100
+@@ -424,7 +424,7 @@
+
+ ---------------------------------------- mf*/
+
+-int gapby (int ival, char *ch, int ioff, int ilen) {
++void gapby (int ival, char *ch, int ioff, int ilen) {
+
+ char *ch1;

--- a/cfchecker/build.sh
+++ b/cfchecker/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON -s setup.py install --prefix=$PREFIX

--- a/cfchecker/meta.yaml
+++ b/cfchecker/meta.yaml
@@ -1,0 +1,40 @@
+package:
+    name: cfchecker
+    version: 2.0.5
+
+source:
+    fn: cfchecker-2.0.5ceda.p1.tar.gz
+    url: https://pypi.python.org/packages/source/c/cfchecker/cfchecker-2.0.5ceda.p1.tar.gz
+    sha1: 8709708c8c9417e91403a0e0aa539d3bae55f346
+    patches:
+        - patch.diff  # [osx]
+
+build:
+    number: 1
+
+    entry_points:
+        - cfchecks = cfchecker:cfchecks_main
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - cdat-lite
+        - udunits 2.*
+    run:
+        - python
+        - numpy
+        - setuptools
+        - cdat-lite
+        - udunits 2.*
+
+test:
+    commands:
+        - cfchecks -h
+    imports:
+        - cfchecker
+
+about:
+  home: https://pypi.python.org/pypi/cfchecker
+  license: BSD
+  summary: The NetCDF Climate Forcast Conventions compliance checker.

--- a/cfchecker/meta.yaml
+++ b/cfchecker/meta.yaml
@@ -20,13 +20,13 @@ requirements:
         - python
         - setuptools
         - cdat-lite
-        - udunits 2.*
+        - udunits2
     run:
         - python
         - numpy
         - setuptools
         - cdat-lite
-        - udunits 2.*
+        - udunits2
 
 test:
     commands:

--- a/cfchecker/patch.diff
+++ b/cfchecker/patch.diff
@@ -1,0 +1,13 @@
+--- src/cfchecker/cfchecks.orig.py	2014-09-26 08:10:49.000000000 +0100
++++ src/cfchecker/cfchecks.py	2014-09-26 08:11:27.000000000 +0100
+@@ -49,7 +49,9 @@
+ # Use ctypes to interface to the UDUNITS-2 shared library
+ # The udunits2 library needs to be in a standard path o/w export LD_LIBRARY_PATH
+ from ctypes import *
+-udunits=CDLL("libudunits2.so")
++import sys
++import os.path
++udunits = cdll.LoadLibrary(os.path.join(sys.prefix, 'lib', "libudunits2.dylib"))
+
+ STANDARDNAME = 'http://cf-pcmdi.llnl.gov/documents/cf-standard-names/standard-name-table/current/cf-standard-name-table.xml'
+ AREATYPES = 'http://cf-pcmdi.llnl.gov/documents/cf-standard-names/area-type-table/current/area-type-table.xml'

--- a/ecmwf_grib/build.sh
+++ b/ecmwf_grib/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+$SYS_PYTHON -c "import conda_build; print conda_build.__file__;"
+
+mkdir -p $PREFIX/bin
+cp $SYS_PYTHON-config $PREFIX/bin/
+
+LDFLAGS="-L$PREFIX/lib -Wl,-rpath,$PREFIX/lib" PYTHON="$PYTHON" PYTHON_LDFLAGS="$PREFIX/lib" CFLAGS="-fPIC -I$PREFIX/include" ./configure --with-jasper=$PREFIX/lib --disable-fortran --prefix=$PREFIX --enable-python
+
+make
+make install
+
+
+# For some reason the installer places the Python files in a sub-directory
+# of site-packages called "grib_api". (NB. The sub-directory is not a package.)
+# The install instructions in python/README include the suggestion:
+#   Add this folder to your PYTHONPATH and you are ready to go.
+# Instead of that, we just rename the directory and make it a package.
+mv $SP_DIR/grib_api $SP_DIR/gribapi
+mv $SP_DIR/gribapi/gribapi.py $SP_DIR/gribapi/__init__.py
+

--- a/ecmwf_grib/meta.yaml
+++ b/ecmwf_grib/meta.yaml
@@ -1,0 +1,34 @@
+package:
+    name: ecmwf_grib
+    version: "1.12.1"
+
+source:
+    fn: grib_api-1.12.1.tar.gz
+    url: https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-1.12.1.tar.gz
+    sha1: b769ac5db70703f0d944d93aafbbeee7513958f1
+
+build:
+    number: 2
+    detect_binary_files_with_prefix: true
+
+requirements:
+    build:
+        - python
+        - numpy
+        - jasper
+
+    run:
+        - python
+        - numpy
+        - jasper
+
+test:
+    commands:
+        - ls $(grib_info -t) | head -n 2   # prints the test data directory.
+    imports:
+        - gribapi
+
+about:
+    home: https://software.ecmwf.int/wiki/display/GRIB/Home
+    license: Apache License, Version 2.0
+    summary: The ECMWF API for encoding and decoding WMO FM-92 GRIB edition 1 and edition 2 messages.

--- a/jasper/build.sh
+++ b/jasper/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export LDFLAGS=-L$LD_RUN_PATH
+export CFLAGS="-I$PREFIX/include"
+sh configure --prefix=$PREFIX --enable-shared --disable-debug --disable-dependency-tracking
+
+make
+make install

--- a/jasper/meta.yaml
+++ b/jasper/meta.yaml
@@ -1,0 +1,26 @@
+package:
+    name: jasper
+    version: "1.900.1"
+
+source:
+    fn: jasper-1.900.1.zip
+    url: http://www.ece.uvic.ca/~frodo/jasper/software/jasper-1.900.1.zip
+    sha1: 9c5735f773922e580bf98c7c7dfda9bbed4c5191
+
+build:
+    number: 2
+
+requirements:
+    build:
+        - jpeg
+    run:
+        - jpeg
+
+test:
+    commands:
+        - jasper --version
+
+about:
+  home: http://www.ece.uvic.ca/~frodo/jasper/
+  license: http://www.ece.uvic.ca/~frodo/jasper/LICENSE
+  summary: A reference implementation of the codec specified in the JPEG-2000 Part-1 standard.

--- a/libmo_unpack/build.sh
+++ b/libmo_unpack/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+cd libmo_unpack
+
+if [[ $(uname) == Darwin ]]
+then
+   # Just build for this version for now.
+   unset MACOSX_DEPLOYMENT_TARGET
+   gcc -c -fPIC -O3 -mfpmath=sse -msse -I include -D_LARGEFILE_SOURCE -D_DARWIN_SOURCE *.c
+
+   ld -dylib -undefined dynamic_lookup -arch x86_64 -o lib/libmo_unpack.dylib *.o
+else
+   gcc -c -fPIC -O4 -mfpmath=sse -msse -I include -D_LARGEFILE_SOURCE *.c
+
+   gcc -shared -Wl,-soname,libmo_unpack.so -o lib/libmo_unpack.so *.o
+fi
+
+# Actually install the built product.
+mkdir $PREFIX/lib $PREFIX/include
+cp lib/* $PREFIX/lib
+cp include/* $PREFIX/include

--- a/libmo_unpack/meta.yaml
+++ b/libmo_unpack/meta.yaml
@@ -1,0 +1,11 @@
+package:
+    name: libmo_unpack
+    version: !!str 2.0.3
+
+source:
+    fn: unpack-160114.tgz
+    url: https://puma.nerc.ac.uk/trac/UM_TOOLS/raw-attachment/wiki/unpack/unpack-160114.tgz
+
+about:
+    home: https://puma.nerc.ac.uk/trac/UM_TOOLS/wiki/unpack
+    summary: Met Office PP-Unpacking Code

--- a/owslib/build.sh
+++ b/owslib/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+

--- a/owslib/meta.yaml
+++ b/owslib/meta.yaml
@@ -1,0 +1,36 @@
+package:
+  name: owslib
+  version: !!str 0.8.12
+
+source:
+
+  git_url: https://github.com/geopython/OWSLib.git
+  git_tag: 0.8.12
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - python-dateutil
+    - pytz
+
+  run:
+    - python
+    - python-dateutil
+    - pytz
+
+test:
+  # Python imports
+  imports:
+    - owslib.coverage
+    - owslib.waterml
+    - owslib.swe.observation
+    - owslib.swe.sensor
+    - owslib
+    - owslib.feature
+    - owslib.swe
+
+about:
+  home: https://geopython.github.io/OWSLib
+  license: BSD License
+  summary: 'OGC Web Service utility library'

--- a/proj4/build.sh
+++ b/proj4/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix=$PREFIX --without-jni
+make
+make install

--- a/proj4/meta.yaml
+++ b/proj4/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: proj4
+  version: !!str 4.8.0
+source:
+  fn:  proj-4.8.0.tar.gz
+  url: http://download.osgeo.org/proj/proj-4.8.0.tar.gz
+
+about:
+  home: http://trac.osgeo.org/proj/
+  license: MIT
+  summary: 'Cartographic projection software'

--- a/pyepsg/build.sh
+++ b/pyepsg/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/pyepsg/meta.yaml
+++ b/pyepsg/meta.yaml
@@ -1,0 +1,20 @@
+package:
+    name: pyepsg
+    version: "0.2.0"
+
+source:
+    git_url: https://github.com/rhattersley/pyepsg.git
+    git_tag: v0.2.0
+
+requirements:
+    build:
+        - python
+
+    run:
+        - python
+        - requests
+
+about:
+    home: https://pypi.python.org/pypi/pyepsg
+    license: LGPL
+    summary: Easy access to the EPSG database via http://epsg.io/

--- a/pyepsg/upload_all.sh
+++ b/pyepsg/upload_all.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+conda config --set binstar_upload yes
+
+for PY in 27 33 34
+do
+    export CONDA_PY=$PY
+    conda build .
+done

--- a/pyke/build.sh
+++ b/pyke/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/pyke/meta.yaml
+++ b/pyke/meta.yaml
@@ -1,0 +1,24 @@
+package:
+    name: pyke
+    version: "1.1.1"
+
+source:
+    fn: pyke-1.1.1.zip
+    url: http://downloads.sourceforge.net/project/pyke/pyke/1.1.1/pyke-1.1.1.zip?r=&ts=1403707359&use_mirror=garr
+    sha1: 2d657257fa2181d85fbfb69701b91226deb8b4e0
+
+requirements:
+    build:
+        - python
+
+    run:
+        - python
+
+test:
+    imports:
+        - pyke
+
+about:
+    home: http://sourceforge.net/projects/pyke
+    license: MIT
+    summary: Python Knowledge Engine and Automatic Python Program Generator.

--- a/pyshp/build.sh
+++ b/pyshp/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/pyshp/meta.yaml
+++ b/pyshp/meta.yaml
@@ -1,0 +1,22 @@
+package:
+    name: pyshp
+    version: "1.2.1"
+
+source:
+    fn: pyshp-1.2.1.tar.gz
+    url: https://pypi.python.org/packages/source/p/pyshp/pyshp-1.2.1.tar.gz
+    sha1: b6d7d526b530029af6fc7986ac0562231f7a63c7
+
+requirements:
+    build:
+        - python
+        - setuptools
+
+    run:
+        - python
+        - setuptools
+
+about:
+    home: https://pypi.python.org/pypi/pyshp
+    license: MIT
+    summary: Pure Python read/write support for ESRI Shapefile format.

--- a/python-dateutil/build.sh
+++ b/python-dateutil/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/python-dateutil/meta.yaml
+++ b/python-dateutil/meta.yaml
@@ -1,0 +1,30 @@
+package:
+  name: python-dateutil
+  version: !!str 2.2
+
+source:
+  fn: python-dateutil-2.2.tar.gz
+  url: https://pypi.python.org/packages/source/p/python-dateutil/python-dateutil-2.2.tar.gz
+  md5: c1f654d0ff7e33999380a8ba9783fd5c
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - six
+
+  run:
+    - python
+    - six
+
+test:
+  # Python imports
+  imports:
+    - dateutil
+    - dateutil.zoneinfo
+
+about:
+  home: http://labix.org/python-dateutil
+  license: BSD License
+  summary: 'Extensions to the standard Python datetime module'
+

--- a/pyugrid/build.sh
+++ b/pyugrid/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/pyugrid/meta.yaml
+++ b/pyugrid/meta.yaml
@@ -1,0 +1,25 @@
+package:
+    name: pyugrid
+    version: "0.1.1"
+
+source:
+    git_url: https://github.com/pyugrid/pyugrid.git
+    git_tag: 0c1387ee561683bc4e1122cd21a06683f556aa06
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - netcdf4
+    run:
+        - python
+        - numpy
+        - netcdf4
+
+test:
+    imports:
+        - pyugrid
+
+about:
+    home: https://github.com/pyugrid/pyugrid
+    summary: A Python API to utilize data written using the unstructured grid UGRID conventions.

--- a/udunits2/build.sh
+++ b/udunits2/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ ! -f configure ];
+then
+   # Make the configure file. Need autoreconf, libtool, libexpat-dev for this.
+   autoreconf -i --force
+fi
+
+./configure --prefix=$PREFIX
+make
+make install

--- a/udunits2/meta.yaml
+++ b/udunits2/meta.yaml
@@ -9,7 +9,6 @@ source:
 
 build:
     number: 1
-    detect_binary_files_with_prefix: true
 
 requirements:
   build:
@@ -22,4 +21,4 @@ test:
 
 about:
   home: http://www.unidata.ucar.edu/software/udunits/
-  summary: The UDUNITS package supports units of physical quantities.
+  summary: 'A library for manipulating units of physical quantities.'

--- a/udunits2/meta.yaml
+++ b/udunits2/meta.yaml
@@ -1,0 +1,25 @@
+package:
+    name: udunits2
+    version: 2.2.17
+
+source:
+    fn: v2.2.17.tar.gz
+    url: https://github.com/Unidata/UDUNITS-2/archive/v2.2.17.tar.gz
+    sha1: 3dfb7b1f18e21ac5366127778bbfd50ab5b7cf0a
+
+build:
+    number: 1
+    detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - autoconf
+    - libtool
+
+test:
+    commands:
+        - udunits2 -h
+
+about:
+  home: http://www.unidata.ucar.edu/software/udunits/
+  summary: The UDUNITS package supports units of physical quantities.

--- a/udunitspy/meta.yaml
+++ b/udunitspy/meta.yaml
@@ -30,14 +30,14 @@ requirements:
   build:
     - python
     - setuptools
-    - udunits
+    - udunits2
     - numexpr >=2.1
     - pytest >=2.3.2
     - pytest-cov >=1.6
 
   run:
     - python
-    - udunits
+    - udunits2
     - numexpr >=2.1
     - pytest >=2.3.2
     - pytest-cov >=1.6


### PR DESCRIPTION
This PR adds the packges from `conda-recipes-scitools` as "regular" directories, detaching the submodule.

(Unfortunately a clean "revert" was not possible.)

Note that I purposely left iris out.  The build we use comes from a branch that fixes https://github.com/SciTools/iris/issues/1287, using the latest iris version would break our workflow.  I am working to get PR https://github.com/SciTools/iris/pull/1502 merged so we can update our iris package.

@rsignell-usgs Let me know if you find any problems building the packages.