### PR TITLE
Workaround rdflib-sparqlwrapper circ dependency

### DIFF
--- a/rasterio/meta.yaml
+++ b/rasterio/meta.yaml
@@ -1,30 +1,14 @@
 package:
   name: rasterio
-  version: "0.15.1"
+  version: "0.18"
 
 source:
-  git_tag: "0.15.1"
-  git_url: https://github.com/mapbox/rasterio.git
-#  patches:
-   # List any patch files here
-   # - fix.patch
+  fn: rasterio-0.18.tar.gz
+  url: https://pypi.python.org/packages/source/r/rasterio/rasterio-0.18.tar.gz
+  md5: 9e59c3868ac5e064cc564d409022d028
 
 build:
   number: 0
-  #preserve_egg_dir: True
-  #entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    # - pyshp = pyshp:main
-    #
-    # Would create an entry point called pyshp that calls pyshp.main()
-
-
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
-
 
   entry_points:
     - rio = rasterio.rio.main:cli
@@ -34,6 +18,7 @@ requirements:
     - affine >=1.0
     - cython >=0.20
     - click
+    - cligj
     - enum34
     - gdal
     - numpy >=1.8
@@ -43,6 +28,7 @@ requirements:
   run:
     - affine >=1.0
     - click
+    - cligj
     - enum34
     - gdal
     - numpy >=1.8
@@ -55,7 +41,3 @@ test:
 about:
   home: https://github.com/mapbox/rasterio
   license: BSD
-
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml

--- a/rdflib/build.sh
+++ b/rdflib/build.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
 
+wget -O $PREFIX/lib/python2.7/site-packages/SPARQLWrapper-1.6.4-py2.7.egg https://pypi.python.org/packages/2.7/S/SPARQLWrapper/SPARQLWrapper-1.6.4-py2.7.egg#md5=1ff0d9c168ed302f03901d753a1a76c5
 $PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.

--- a/rdflib/meta.yaml
+++ b/rdflib/meta.yaml
@@ -1,74 +1,58 @@
 package:
-  name: rdflib
-  version: !!str 4.1.2
+   name: rdflib
+   version: "4.1.2"
 
 source:
-  fn: rdflib-4.1.2.tar.gz
-  url: https://pypi.python.org/packages/source/r/rdflib/rdflib-4.1.2.tar.gz
-  md5: a356cf3bdfe1a72d240d151ce5662b84
-#  patches:
-   # List any patch files here
-   # - fix.patch
+   fn: rdflib-4.1.2.tar.gz
+   url: https://pypi.python.org/packages/source/r/rdflib/rdflib-4.1.2.tar.gz
+   md5: a356cf3bdfe1a72d240d151ce5662b84
+
 
 build:
-  #preserve_egg_dir: True
-  entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    # - rdflib = rdflib:main
-    #
-    # Would create an entry point called rdflib that calls rdflib.main()
-
-    - rdfpipe = rdflib.tools.rdfpipe:main
-    - csv2rdf = rdflib.tools.csv2rdf:main
-    - rdf2dot = rdflib.tools.rdf2dot:main
-    - rdfs2dot = rdflib.tools.rdfs2dot:main
-    - rdfgraphisomorphism = rdflib.tools.graphisomorphism:main
-
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
+   entry_points:
+   - rdfpipe = rdflib.tools.rdfpipe:main
+   - csv2rdf = rdflib.tools.csv2rdf:main
+   - rdf2dot = rdflib.tools.rdf2dot:main
+   - rdfs2dot = rdflib.tools.rdfs2dot:main
+   - rdfgraphisomorphism = rdflib.tools.graphisomorphism:main
 
 requirements:
   build:
-    - python
-    - setuptools
-    - isodate
-    - pyparsing
-#   - sparqlwrapper
-    - html5lib
+   - python
+   - setuptools
+   - isodate
+   - pyparsing
+   # - sparqlwrapper # Added via build.sh to avoid circular dependency.
+   - html5lib
+   - six
 
   run:
-    - python
-    - isodate
-    - pyparsing
-#   - sparqlwrapper
-    - html5lib
+   - python
+   - setuptools
+   - isodate
+   - pyparsing
+   # - sparqlwrapper
+   - html5lib
+   - six
 
 test:
-  # Python imports
-  imports:
-    - rdflib
+   # Python imports NOTE: Cannot test installation without sparqlwrapper!
+   # imports:
+   # - rdflib
+   # - rdflib.namespace
 
-  commands:
-    # You can put test commands to be run here.  Use this to test that the
-    # entry points work.
-
-    - rdfpipe --help
-
-  # You can also put a file called run_test.py in the recipe that will be run
-  # at test time.
-
-  # requires:
-    # Put any additional test requirements here.  For example
-    # - nose
+   commands:
+   # You can put test commands to be run here. Use this to test that the
+   # entry points work.
+   - rdfpipe --help
+   # You can also put a file called run_test.py in the recipe that will be run
+   # at test time.
+   # requires:
+   # Put any additional test requirements here. For example
+   # - nose
 
 about:
   home: https://github.com/RDFLib/rdflib
   license: BSD License
   summary: 'RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information'
 
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml

--- a/sparqlwrapper/meta.yaml
+++ b/sparqlwrapper/meta.yaml
@@ -1,29 +1,11 @@
 package:
   name: sparqlwrapper
-  version: !!str 1.6.0
+  version: "1.6.4"
 
 source:
-  fn: SPARQLWrapper-1.6.0.tar.gz
-  url: https://pypi.python.org/packages/source/S/SPARQLWrapper/SPARQLWrapper-1.6.0.tar.gz
-  md5: 5d9e0ce0949e17eab949ae82f3fcad4d
-#  patches:
-   # List any patch files here
-   # - fix.patch
-
-# build:
-  #preserve_egg_dir: True
-  #entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    # - sparqlwrapper = sparqlwrapper:main
-    #
-    # Would create an entry point called sparqlwrapper that calls sparqlwrapper.main()
-
-
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
+  fn: SPARQLWrapper-1.6.4.tar.gz
+  url: https://pypi.python.org/packages/source/S/SPARQLWrapper/SPARQLWrapper-1.6.4.tar.gz
+  md5: e30a18bd53e16c93e5fc0a2cc736ad34
 
 requirements:
   build:
@@ -36,28 +18,10 @@ requirements:
     - rdflib >=2.4.2
 
 test:
-  # Python imports
   imports:
     - SPARQLWrapper
-    - sparqlwrapper
-
-  #commands:
-    # You can put test commands to be run here.  Use this to test that the
-    # entry points work.
-
-
-  # You can also put a file called run_test.py in the recipe that will be run
-  # at test time.
-
-  # requires:
-    # Put any additional test requirements here.  For example
-    # - nose
 
 about:
   home: http://sparql-wrapper.sourceforge.net/
   license: W3C License
   summary: 'SPARQL Endpoint interface to Python'
-
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml


### PR DESCRIPTION
This is a workaround to fix #17.  We must build `rdflib` and then `sparqlwrapper`.  When installing we have to install `sparqlwrapper` and get `rdflib` automatically.  It will not work if someone install `rdflib` only!