### PR TITLE
Fixed windows build.

### DIFF
--- a/owslib/bld.bat
+++ b/owslib/bld.bat
@@ -1,0 +1,1 @@
+%PYTHON% setup.py install --single-version-externally-managed --record=record.txt


### PR DESCRIPTION
@rsignell-usgs we forgot the `bld.bat`.  With this PW we can build any OWSLib version and forget about OWSLib issues here https://github.com/ocefpaf/utilities/issues/1.