### PR TITLE
Using master branch to build pygridgen.

### DIFF
--- a/pygridgen/meta.yaml
+++ b/pygridgen/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_url: https://github.com/phobson/pygridgen.git
-  git_tag: master
+  git_tag: develop
 
 build:
   number: 1

--- a/pygridgen/meta.yaml
+++ b/pygridgen/meta.yaml
@@ -1,28 +1,12 @@
-
 package:
   name: pygridgen
   version: !!str 0.1
 
 source:
   git_url: https://github.com/phobson/pygridgen.git
-  git_tag: new-paths
-#  patches:
-   # List any patch files here
-   # - fix.patch
+  git_tag: master
 
 build:
-  #preserve_egg_dir: True
-  #entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    # - seaborn = seaborn:main
-    #
-    # Would create an entry point called seaborn that calls seaborn.main()
-
-
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
   number: 1
 
 requirements:
@@ -39,7 +23,7 @@ requirements:
     - pandas
     - numpy
     - matplotlib
-    - basemap 
+    - basemap
     - nose
 
 test:


### PR DESCRIPTION
`new-paths` branch is no longer there.  I am using `master`, but we should confirm with @phobson if that is the right branch to build pygridgen.