### PR TITLE
Updated rasterio to 0.18 and use PyPI source.

### DIFF
--- a/rasterio/meta.yaml
+++ b/rasterio/meta.yaml
@@ -1,30 +1,14 @@
 package:
   name: rasterio
-  version: "0.15.1"
+  version: "0.18"
 
 source:
-  git_tag: "0.15.1"
-  git_url: https://github.com/mapbox/rasterio.git
-#  patches:
-   # List any patch files here
-   # - fix.patch
+  fn: rasterio-0.18.tar.gz
+  url: https://pypi.python.org/packages/source/r/rasterio/rasterio-0.18.tar.gz
+  md5: 9e59c3868ac5e064cc564d409022d028
 
 build:
   number: 0
-  #preserve_egg_dir: True
-  #entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    # - pyshp = pyshp:main
-    #
-    # Would create an entry point called pyshp that calls pyshp.main()
-
-
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
-
 
   entry_points:
     - rio = rasterio.rio.main:cli
@@ -34,6 +18,7 @@ requirements:
     - affine >=1.0
     - cython >=0.20
     - click
+    - cligj
     - enum34
     - gdal
     - numpy >=1.8
@@ -43,6 +28,7 @@ requirements:
   run:
     - affine >=1.0
     - click
+    - cligj
     - enum34
     - gdal
     - numpy >=1.8
@@ -55,7 +41,3 @@ test:
 about:
   home: https://github.com/mapbox/rasterio
   license: BSD
-
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml


### PR DESCRIPTION
I found that the cython error we got were due to the GitHub tagged version.  I believe there are some left over cythonized sourced there.  Once I moved to a clean source (PyPI) things worked out smoothly for all rasterio version.

Here I also updated it to the latest version (0.18).