### PR TITLE
Fixed AppVeyor and Binstar URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![build status](http://img.shields.io/travis/ioos/conda-recipes/master.svg?style=flat)](https://travis-ci.org/ioos/conda-recipes)
 <span>&nbsp;</span>
-[![Build status](https://ci.appveyor.com/api/projects/status/github/ioos/conda-recipes?branch=master&svg=true)](https://ci.appveyor.com/api/projects/status/github/ioos/conda-recipes?branch=master&svg=true)
+[![Build status](https://ci.appveyor.com/api/projects/status/github/ioos/conda-recipes?branch=master&svg=true)](https://ci.appveyor.com/project/ocefpaf/conda-recipes)
 
 
 conda-recipes for IOOS packages
 
 The recipes here create conda packages that can be uploaded to
-Binstar.org[http://binstar.org] and shared with the community.
+[Binstar.org](http://binstar.org) and shared with the community.
 
 For IOOS python users, the
 [Anaconda Scientific Python Distribution](https://store.continuum.io/cshop/anaconda/)


### PR DESCRIPTION
We must change `project/ocefpaf` to `project/ioos` in the future...