### PR TITLE
Adding psycopg2 (Cheating: using pip).

### DIFF
--- a/psycopg2/bld.bat
+++ b/psycopg2/bld.bat
@@ -1,0 +1,1 @@
+pip install psycopg2

--- a/psycopg2/build.sh
+++ b/psycopg2/build.sh
@@ -1,0 +1,1 @@
+pip install psycopg2

--- a/psycopg2/meta.yaml
+++ b/psycopg2/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: psycopg2
+  version: "2.5.4"
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python
+
+about:
+  home: http://initd.org/psycopg/
+  license: GNU Library or Lesser General Public License (LGPL) or  Zope Public License
+  summary: "Python-PostgreSQL Database Adapter"


### PR DESCRIPTION
@rsignell-usgs This will download a binary from PyPI using pip and create a conda package from it.  I remember reading about this in the conda e-mail list somewhere...

The psycopg2 package works only on win64 and linux (no win32).  With that we can build `pycsw` for [win64](https://binstar.org/ioos/pycsw).  However, both packages are not tested.