### PR TITLE
Some recipe improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
 
     matrix:
         - CONDA_PY=27  CONDA_NPY=18
+        - CONDA_PY=27  CONDA_NPY=19
 
 before_install:
     - sudo apt-get update -qq

--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -1,42 +1,46 @@
 package:
   name: iris
   version: !!str 1.7.2_DEV_9e1fd13
+
 source:
   git_url: https://github.com/rhattersley/iris.git
   git_tag: lazy-dtype
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
     - python
-    - biggus
-    - numpy
     - scipy
-    - udunits2
+    - biggus
+    - cartopy >=0.11
     - netcdf4
+    - udunits2
     - pyke
-    - cartopy
-    - geos
-    - nose
     - setuptools
+    - libmo_unpack  # [not win]
+
   run:
     - python
-    - biggus
-    - numpy
     - scipy
-    - udunits2
-    - netcdf4
-    - geos
-    - pyke
-    - cartopy
-    - shapely
+    - biggus
+    - cartopy >=0.11
     - matplotlib
+    - netcdf4
+    - ecmwf_grib >=1.12.1  # [not win]
+    - numpy
+    - pyke
+    - udunits2
+    - libmo_unpack  # [not win]
 
 test:
   imports:
+        - iris
+        # FIXME: This is not working yet!
+        #- iris.fileformats.pp_packing  # [not win]
 
 about:
-  home: http://scitools.org.uk/iris
-  license: Open Government License (UK)
+    home: http://www.scitools.org.uk/iris
+    license: GNU Lesser General Public License
+    summary: "Analyse and visualise meteorological and oceanographic data sets."


### PR DESCRIPTION
In this PR:

- enable grib
- enable pp
- increment build
- added explicit dependency on `libnetcdf >=4.3`

The reason behind the last item is that, somehow, conda downloaded the non-dap enable

`libnetcdf:          4.2.1.1-0                    defaults`

To fix that I had to manually update `libnetcdf`.  In theory, by forcing the dap enabled version, we are OK by just installing iris.

PS: This gist show a small requirements file and what gets installed by it using conda and only the ioos channel.

https://gist.github.com/ocefpaf/e594e228bc8129303006