### PR TITLE
First step to fix windows builds.

### DIFF
--- a/compliance-checker/bld.bat
+++ b/compliance-checker/bld.bat
@@ -1,8 +1,0 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.

--- a/mysql-python/bld.bat
+++ b/mysql-python/bld.bat
@@ -1,8 +1,0 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.

--- a/octant/bld.bat
+++ b/octant/bld.bat
@@ -1,8 +1,0 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.

--- a/pytools/bld.bat
+++ b/pytools/bld.bat
@@ -1,8 +1,0 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.

--- a/rasterio/bld.bat
+++ b/rasterio/bld.bat
@@ -1,8 +1,0 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.

--- a/rtree/bld.bat
+++ b/rtree/bld.bat
@@ -1,8 +1,0 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.

--- a/udunitspy/bld.bat
+++ b/udunitspy/bld.bat
@@ -1,8 +1,0 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.


### PR DESCRIPTION
Removed the following windows build to allow AppVeyor to complete.

rtree/bld.bat
octant/bld.bat
pytools/bld.bat
rasterio/bld.bat
udunitspy/bld.bat
mysql-python/bld.bat
compliance-checker/bld.bat

I will revisit every package again at a later time to fix their windows build individually.