### PR TITLE
Added iris for windows.

### DIFF
--- a/iris/bld.bat
+++ b/iris/bld.bat
@@ -1,0 +1,5 @@
+set SITECFG=lib/iris/etc/site.cfg
+echo [System] > %SITECFG%
+echo udunits2_path = %SCRIPTS%\udunits2.dll >> %SITECFG%
+
+%PYTHON% -sE setup.py install --single-version-externally-managed --record record.txt

--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -1,13 +1,14 @@
 package:
-  name: iris
-  version: !!str 1.7.2_DEV_9e1fd13
+    name: iris
+    version: 1.7.4.dev
 
 source:
-  git_url: https://github.com/rhattersley/iris.git
-  git_tag: lazy-dtype
+    git_url: https://github.com/SciTools/iris.git
+    git_tag: v1.7.x
 
 build:
-  number: 1
+    number: 0  # [win]
+    number: 0  # [not win]
 
 requirements:
   build:
@@ -20,7 +21,6 @@ requirements:
     - pyke
     - setuptools
     - libmo_unpack  # [not win]
-
   run:
     - python
     - scipy
@@ -37,8 +37,7 @@ requirements:
 test:
   imports:
         - iris
-        # FIXME: This is not working yet!
-        #- iris.fileformats.pp_packing  # [not win]
+        - iris.fileformats.pp_packing  # [not win]
 
 about:
     home: http://www.scitools.org.uk/iris

--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -37,7 +37,8 @@ requirements:
 test:
   imports:
         - iris
-        - iris.fileformats.pp_packing  # [not win]
+        # pp is not working yet.
+        #- iris.fileformats.pp_packing  # [not win]
 
 about:
     home: http://www.scitools.org.uk/iris


### PR DESCRIPTION
This PR adds iris build for windows (`bld.bat`) and updates iris to the latest release.

The update is because version 1.7.2 cannot by built on windows.  However, we must add `iris==1.7.2_DEV_9e1fd13` to our requirements file on Linux to avoid installing the latest version until this bug is fixed:

https://github.com/SciTools/iris/pull/1502

and live with the bug on windows...