### PR TITLE
Fix win32 build.

### DIFF
--- a/psycopg2/bld.bat
+++ b/psycopg2/bld.bat
@@ -1,1 +1,5 @@
-pip install psycopg2
+IF %ARCH% == 32 (
+   pip install git+https://github.com/nwcell/psycopg2-windows.git@win32-py27#egg=psycopg2
+) ELSE (
+   pip install psycopg2==2.5.2
+)

--- a/psycopg2/meta.yaml
+++ b/psycopg2/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: psycopg2
-  version: "2.5.4"
+  version: "2.5.2"
 
 requirements:
   build:


### PR DESCRIPTION
This PR adds an IF/ELSE clause in the `bld.bat` to install the proper `psycopg2` binary for each ARCH.  Because the binary available for win32 is 2.5.2 I downgraded the package to that version.

(`pycsw` is the only package that uses `psycopg2`.)

This PR closes #81.