### PR TITLE
Added obvious-ci

### DIFF
--- a/obvious-ci/bld.bat
+++ b/obvious-ci/bld.bat
@@ -1,0 +1,1 @@
+%PYTHON% setup.py install --single-version-externally-managed --record=record.txt

--- a/obvious-ci/build.sh
+++ b/obvious-ci/build.sh
@@ -1,0 +1,1 @@
+${PYTHON} setup.py install --single-version-externally-managed --record=record.txt

--- a/obvious-ci/meta.yaml
+++ b/obvious-ci/meta.yaml
@@ -1,0 +1,24 @@
+package:
+    name: obvious-ci
+    version: '0.3.dev'
+
+source:
+    git_url: https://github.com/pelson/Obvious-CI.git
+    git_tag: master
+
+requirements:
+    build:
+        - python
+        - setuptools
+
+    run:
+        - python
+        - setuptools
+        - binstar
+        - conda
+        - conda-build
+
+about:
+    home: https://github.com/pelson/Obvious-CI
+    license: GPL
+    summary: Simplify the implementation of continuous integration such as Travis CI and appveyor.


### PR DESCRIPTION
`obvious-ci` as a first step to write the "How to run `obvci_conda_build_dir.py` on https://github.com/ioos/conda-recipes."

@rsignell-usgs Can you review and merge?