### PR TITLE
re-wrote libspatialindex to download source tarball, rather than pull from gitHub

### DIFF
--- a/libspatialindex/build.sh
+++ b/libspatialindex/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #cmake -DCMAKE_INSTALL_PREFIX=$PREFIX .
-./autogen.sh 
+#./autogen.sh 
 ./configure --prefix=$PREFIX
 make
 make install

--- a/libspatialindex/meta.yaml
+++ b/libspatialindex/meta.yaml
@@ -3,8 +3,9 @@ package:
   version: 1.8.5
 
 source:
-  git_url: https://github.com/libspatialindex/libspatialindex.git
-  git_tag: 1.8.5
+  fn: spatialindex-src-1.8.5.tar.gz
+  url: http://download.osgeo.org/libspatialindex/spatialindex-src-1.8.5.tar.gz
+  md5: 4065c6218ce3d1c4906beb3a313470db
 
 build:
   number: 0


### PR DESCRIPTION

This is so that autoconf will have already been run -- so you can build with a simple:

./configure && make && make install

Note that OS-X doesn't have autotools installed by default, so this makes it a lot easier to build on OS-X

And it seems the "official" source tarball is probably the way to go anyway.