### PR TITLE
Install gfortran on Linux only.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ env:
 
 before_install:
     - sudo apt-get update -qq
-    - sudo apt-get install gfortran
-
-install:
+    # Install fortran compiler for octant.
+    - if [[ "$OSTYPE" == "linux-gnu" ]]; then sudo apt-get install gfortran; fi
     # Install makeinfo - needed for constructing configuration files via autoreconf (in particular for udunits).
     - if [[ "$OSTYPE" == "linux-gnu" ]]; then sudo apt-get install texinfo; fi
 
+install:
     - wget https://raw.githubusercontent.com/pelson/Obvious-CI/v0.1.0/bootstrap-obvious-ci-and-miniconda.py
     - python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 2 --without-obvci && source ~/miniconda/bin/activate root
     - conda config --set show_channel_urls True && conda config --add channels http://conda.binstar.org/ioos/channel/main


### PR DESCRIPTION
- Installs gfortran (via apt-get) only for Linux.
- Removed sudo calls (not need on travis-ci)