### PR TITLE
Added flags to the setup.py install command so that setuptools wouldn't ...

### DIFF
--- a/wicken/build.sh
+++ b/wicken/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed --record=/tmp/record.txt
 
 # Add more build steps here, if they are necessary.
 


### PR DESCRIPTION
...check for dependencies.

It was having trouble finding petulant-bear, even though it was there.

NOTE: setuptools is often a pain in this way -- it expects eggs, etc, and conda overrides that. I"m guessing tha the hyphen in petulant-bear is messing things up...

I got this solution from:

https://groups.google.com/a/continuum.io/forum/#!topic/conda/3Jw2cnsL_v8