### PR TITLE
Updated udunits build to use official tarball from unidata.

### DIFF
--- a/udunits2/build.sh
+++ b/udunits2/build.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-if [ ! -f configure ];
-then
-   # Make the configure file. Need autoreconf, libtool, libexpat-dev for this.
-   autoreconf -i --force
-fi
+## should have a configure file if you got the offical source tarball
+# if [ ! -f configure ];
+# then
+#    # Make the configure file. Need autoreconf, libtool, libexpat-dev for this.
+#    autoreconf -i --force
+# fi
 
 ./configure --prefix=$PREFIX
 make

--- a/udunits2/build.sh
+++ b/udunits2/build.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-## should have a configure file if you got the offical source tarball
-# if [ ! -f configure ];
-# then
-#    # Make the configure file. Need autoreconf, libtool, libexpat-dev for this.
-#    autoreconf -i --force
-# fi
+# should have a configure file if you got the offical source tarball
+# but if it got pulled from the git repo, the configure script needs to be 
+# rebuilt
+if [ ! -f configure ];
+then
+   # Make the configure file. Need autoreconf, libtool, libexpat-dev for this.
+   autoreconf -i --force
+fi
 
 ./configure --prefix=$PREFIX
 make

--- a/udunits2/meta.yaml
+++ b/udunits2/meta.yaml
@@ -1,11 +1,10 @@
 package:
     name: udunits2
-    version: "2.2.17"
+    version: "2.2.18"
 
 source:
-    fn: v2.2.17.tar.gz
-    url: https://github.com/Unidata/UDUNITS-2/archive/v2.2.17.tar.gz
-    sha1: 3dfb7b1f18e21ac5366127778bbfd50ab5b7cf0a
+    fn: udunits-2.2.18.tar.gz
+    url: ftp://ftp.unidata.ucar.edu/pub/udunits/udunits-2.2.18.tar.gz
 
 requirements:
   build:


### PR DESCRIPTION
Updated udunits build to use official tarball from unidata, rather than gitHub repo.

This gets you a version with a configure script ready to go.

Also updated to newer version: 2.2.18 -- 'cause why not?