### PR TITLE
New token

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
   BINSTAR_TOKEN:
-    secure: Yz49TWLWFQw2nEqbFIOh4dkWqsfeSIodT5GIMXA6zJ4QltHdTLiiB3NTI3n3hlig
+    secure: a0u2Qr8yHKQQHhFB+oWUg2tWeQYyUxHtFVk1ofwIPDaW9L5FrIC8fSns+Zbq0Kno
 
   matrix:
     - TARGET_ARCH: "x86"

--- a/oceans/meta.yaml
+++ b/oceans/meta.yaml
@@ -7,7 +7,7 @@ source:
   git_branch: master
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -19,7 +19,7 @@ requirements:
     - pandas >=0.13
     - gsw >=3.0.2
     - seawater
-    - shapely  # [not win]
+    - shapely
     - netcdf4
     - ctd
 
@@ -31,7 +31,7 @@ requirements:
     - pandas >=0.13
     - gsw >=3.0.2
     - seawater
-    - shapely  # [not win]
+    - shapely
     - netcdf4
     - ctd
 


### PR DESCRIPTION
The Windows binaries are not uploaded to binstar when merging, only when build from @ocefpaf account.

This PR replaces the APPVeyor TOKEN in an attempt to fix it.  The test package is `oceans`, it should get build in the PR, but not uploaded!  The upload should happen only when merging.