### PR TITLE
Updated to latest release.

### DIFF
--- a/utilities/meta.yaml
+++ b/utilities/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: utilities
-  version: "0.2.0"
+  version: "0.2.1"
 
 source:
   git_url: https://github.com/pyoceans/utilities.git
-  git_tag: v0.2.0
+  git_tag: v0.2.1
 
 build:
   number: 0


### PR DESCRIPTION
@rsignell-usgs this release adds a workaround for iris slicing bug on Windows 64.