### PR TITLE
Build on RHEL6  (conda-recipes-scitools #54).

### DIFF
--- a/geos/build.sh
+++ b/geos/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-./configure --prefix=$PREFIX --without-jni
+
+# Problems with cartopy if the -64 flag is not defined. See https://taskman.eionet.europa.eu/issues/14817.
+CFLAGS="-m64" CPPFLAGS="-m64" CXXFLAGS="-m64" LDFLAGS="-m64" FFLAGS="-m64" ./configure --prefix=$PREFIX --without-jni
 make
 make install

--- a/shapely/meta.yaml
+++ b/shapely/meta.yaml
@@ -13,13 +13,11 @@ source:
     - geom.py.patch  # [win]
 
 build:
-  number: 0     # [not win]
-  number: 0     # [win]
+  number: 1
 
 requirements:
   build:
     - python
-    - distribute
     - geos >=3.4
     - cython
     - numpy


### PR DESCRIPTION
@rsignell-usgs This is safe to merge and will not affect the binaries on binstar.  It only makes the package more friendly to old Linux distros.
(If one day we want to use these package on Wakari, we will need this.)