### PR TITLE
Fixes #118.

### DIFF
--- a/00_env_requirements/ioos/ioos_req.txt
+++ b/00_env_requirements/ioos/ioos_req.txt
@@ -7,7 +7,6 @@ rdflib
 geojson
 requests
 ipython-notebook
-libnetcdf=4.2.1.1=1
 xlrd
 mplleaflet
 oceans


### PR DESCRIPTION
@rsignell-usgs this should work on MacOS too.  In the it was a `libnetcdf` update (4.2.1.1 -> 4.3.2-1).  By removing the pinned down built from our req file (4.2.1.1-1) everything works.

PS: We had to pin` libnetcdf` to 4.2.1.1-1 because the build=0 was not Dap enabled and somehow conda was picking that one up.  Version 4.3.2 is OK though.