### PR TITLE
Using lazy_dtype branch (again).

### DIFF
--- a/00_env_requirements/ioos/ioos_req.txt
+++ b/00_env_requirements/ioos/ioos_req.txt
@@ -1,4 +1,4 @@
-iris=1.7.2_DEV_9e1fd13
+iris
 mpld3
 pyoos
 pandas

--- a/biggus/meta.yaml
+++ b/biggus/meta.yaml
@@ -3,8 +3,11 @@ package:
     version: "0.8.0"
 
 source:
-    git_url: https://github.com/SciTools/biggus.git
-    git_tag: v0.8.0
+    git_url: https://github.com/rhattersley/biggus
+    git_tag: newaxis
+
+build:
+    number: 1
 
 requirements:
     build:

--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -1,10 +1,10 @@
 package:
     name: iris
-    version: 1.7.4.dev
+    version: 1.8.0.dev
 
 source:
-    git_url: https://github.com/SciTools/iris.git
-    git_tag: v1.7.x
+    git_url: https://github.com/rhattersley/iris.git
+    git_tag: lazy-dtype_update2
 
 build:
     number: 0  # [win]


### PR DESCRIPTION
Using `iris` and `biggus` from @rhattersley branch.  This is a workaround until https://github.com/SciTools/iris/pull/1560 get merged.