### PR TITLE
Adding nco.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,8 @@ env:
 
 before_install:
     - sudo apt-get update -qq
-    # Install fortran compiler for octant.
-    - if [[ "$OSTYPE" == "linux-gnu" ]]; then sudo apt-get install gfortran; fi
-    # Install makeinfo - needed for constructing configuration files via autoreconf (in particular for udunits).
-    - if [[ "$OSTYPE" == "linux-gnu" ]]; then sudo apt-get install texinfo; fi
+    # Install makeinfo (autoreconf::udunits), gfortran (octant), antlr (nco).
+    - if [[ "$OSTYPE" == "linux-gnu" ]]; then sudo apt-get install texinfo gfortran antlr libantlr-dev; fi
 
 install:
     - wget https://raw.githubusercontent.com/pelson/Obvious-CI/v0.1.0/bootstrap-obvious-ci-and-miniconda.py

--- a/nco-bindings/build.sh
+++ b/nco-bindings/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/nco-bindings/meta.yaml
+++ b/nco-bindings/meta.yaml
@@ -1,0 +1,33 @@
+package:
+    name: nco-bindings
+    version: "0.0.2"
+
+source:
+    fn: nco-0.0.2.tar.gz
+    url: https://pypi.python.org/packages/source/n/nco/nco-0.0.2.tar.gz
+    md5: bf7f543f7ffb5739eaf6466ca7e60c38
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+        - dateutil
+        - h5py
+        - netcdf4
+        - numpy
+        - scipy
+        - nco
+
+test:
+    imports:
+        - nco
+
+about:
+    home: https://raw2.github.com/jhamman/nco-bindings/
+    license: GPLv2
+    summary: 'python bindings to NCO'

--- a/nco/build.sh
+++ b/nco/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+export HAVE_NETCDF4_H=yes
+export NETCDF_ROOT=$PREFIX
+
+./configure \
+    HAVE_ANTLR=yes \
+    --prefix=$PREFIX \
+    --with-zlib=$PREFIX \
+    --disable-dependency-tracking \
+    --enable-netcdf4 \
+    --disable-static \
+    --disable-udunits \
+    --enable-udunits2 \
+    --disable-dap-opendap \
+    --enable-dap-netcdf
+
+make
+make install

--- a/nco/meta.yaml
+++ b/nco/meta.yaml
@@ -1,0 +1,36 @@
+package:
+  name: nco
+  version: 4.4.8
+
+source:
+  fn: nco-4.4.8.tar.gz
+  url: http://nco.sourceforge.net/src/nco-4.4.8.tar.gz
+  md5: 842a118251da3875e7e2ab2cb0ec77fe
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - curl
+    - zlib
+    - libnetcdf
+    - hdf5
+    - udunits2
+    #- gsl
+    #- antlr
+
+  run:
+    - libnetcdf
+    - udunits2
+
+test:
+  commands:
+    - ncks --help
+    - ncks -M http://test.opendap.org/dap/data/nc/sst.mnmean.nc.gz
+    - ncks http://thredds-test.ucar.edu/thredds/dodsC/testdods/in.nc in.nc
+    - ncap2 -v -s 'a=3' -s 'b=4' -s 'c=sqrt(a^2+b^2)' in.nc out.nc
+
+about:
+  home: http://www.hdfgroup.org/HDF5/
+  license: BSD-style (http://www.hdfgroup.org/ftp/HDF5/current/src/unpacked/COPYING)


### PR DESCRIPTION
@rsignell-usgs this will probably fail or it will produce a defective/incomplete nco.  That is because the default channel does not provide antlr nor [gsl](https://github.com/conda/conda-recipes/tree/master/gsl).

I just want to see the failure to have something to work with.