### PR TITLE
Updated folium to 0.1.4

### DIFF
--- a/folium/meta.yaml
+++ b/folium/meta.yaml
@@ -1,10 +1,11 @@
 package:
-  name: folium
-  version: "0.1.4.dev"
+    name: folium
+    version: "0.1.4"
 
 source:
-  git_url: https://github.com/python-visualization/folium.git
-  git_tag: master
+    fn: folium-0.1.4.tar.gz
+    url: https://pypi.python.org/packages/source/f/folium/folium-0.1.4.tar.gz
+    md5: b5e0c8eac6f92e9806b91eced8586047
 
 build:
   number: 0


### PR DESCRIPTION
Latest folium release:

Popups allow unicode.  (apatil)
Support for https protocol.  (apatil)
Custom popup width.  (ocefpaf)
Support multiPolyLine.  (scari)
Added max and min zoom keywords.  (Paradoxeuh)
Bug Fixes

Remove margins from leaflet-tiles (Fixes #64).  (lennart0901)
Template not found on Windows OSes (Fixes #50).  (Paradoxeuh)
WMS layer on python 3.  (ocefpaf)