### PR TITLE
Updated to 2.2.19

### DIFF
--- a/udunits2/meta.yaml
+++ b/udunits2/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: udunits2
-    version: "2.2.17"
+    version: "2.2.19"
 
 source:
-    fn: v2.2.17.tar.gz
-    url: https://github.com/Unidata/UDUNITS-2/archive/v2.2.17.tar.gz
-    sha1: 3dfb7b1f18e21ac5366127778bbfd50ab5b7cf0a
+    fn: v2.2.19.tar.gz
+    url: https://github.com/Unidata/UDUNITS-2/archive/v2.2.19.tar.gz
+    sha1: 39ff26ae5186573897254b91e97690c67b96cf89
 
 requirements:
   build:


### PR DESCRIPTION
2.2.19
- Added `tsearch.c` and `tsearch.h` to the distribution to support building on Windows.

2.2.18

Library (udunits2(3)):
- Eliminated the use of <unistd.h> on Windows.
- Improved support for static builds.
Units Database:
- Corrected the definition of "dram" and added "fluid_dram".
- Changed the definition of "molecule" to "1/avogadro_constant".
- Added comments and human-readable definitions.
- Improved support for static builds.
Program (udunits2(1)):
- Removed latent bug on Windows in determining the name of the program.
Misc:
- Removed lint discovered by Coverity.