### PR TITLE
Updated appdirs.

### DIFF
--- a/appdirs/bld.bat
+++ b/appdirs/bld.bat
@@ -1,8 +1,2 @@
-"%PYTHON%" setup.py install
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.

--- a/appdirs/build.sh
+++ b/appdirs/build.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/appdirs/meta.yaml
+++ b/appdirs/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: appdirs
-  version: !!str 1.2.0
+  version: "1.4.0"
 
 source:
-  fn: appdirs-1.2.0.zip
-  url: https://pypi.python.org/packages/source/a/appdirs/appdirs-1.2.0.zip
-  md5: 7bc76ee16112388a390ca0139e565d9b
+  fn: appdirs-1.4.0.tar.gz
+  url: https://pypi.python.org/packages/source/a/appdirs/appdirs-1.4.0.tar.gz
+  md5: 1d17b4c9694ab84794e228f28dc3275b
 
 build:
   number: 0
@@ -14,6 +14,7 @@ requirements:
   build:
     - python
     - setuptools
+
   run:
     - python
 


### PR DESCRIPTION
# appdirs 1.4.0

- [PR #42] AppAuthor is now optional on Windows
- [issue 41] Support Jython on Windows, Mac, and Unix-like platforms. Windows support requires JNA.
- [PR #44] Fix incorrect behaviour of the site_config_dir method

# appdirs 1.3.0
- [Unix, issue 16] Conform to XDG standard, instead of breaking it for everybody
- [Unix] Removes gratuitous case mangling of the case, since *nix-es are usually case sensitive, so mangling is not wise
- [Unix] Fixes the uterly wrong behaviour in site_data_dir, return result based on XDG_DATA_DIRS and make room for respecting the standard which specifies XDG_DATA_DIRS is a multiple-value variable
- [Issue 6] Add *_config_dir which are distinct on nix-es, according to XDG specs; on Windows and Mac return the corresponding *_data_dir