### PR TITLE
Bumped the build number.

### DIFF
--- a/obvious-ci/meta.yaml
+++ b/obvious-ci/meta.yaml
@@ -1,10 +1,13 @@
 package:
     name: obvious-ci
-    version: '0.3.dev'
+    version: '0.3.x.dev'
 
 source:
     git_url: https://github.com/pelson/Obvious-CI.git
     git_tag: master
+
+build:
+    number: 1
 
 requirements:
     build:


### PR DESCRIPTION
We are using the master branch (development version 0.3.x), so I bumped the build number to get the latest checkout.  We need this to get the  this fix: https://github.com/pelson/Obvious-CI/pull/4