### PR TITLE
Updated rasterio.

### DIFF
--- a/rasterio/build.sh
+++ b/rasterio/build.sh
@@ -7,12 +7,4 @@ if [ ${UNAME} = 'Darwin' ]; then
     export LDFLAGS="$CFLAGS"
 fi
 
-$PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# copy rasterio scripts to the conda bin directory
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.
+$PYTHON setup.py install --single-version-externally-managed  --record record.txt

--- a/rasterio/meta.yaml
+++ b/rasterio/meta.yaml
@@ -1,43 +1,42 @@
 package:
-  name: rasterio
-  version: "0.18"
+    name: rasterio
+    version: "0.19.1"
 
 source:
-  fn: rasterio-0.18.tar.gz
-  url: https://pypi.python.org/packages/source/r/rasterio/rasterio-0.18.tar.gz
-  md5: 9e59c3868ac5e064cc564d409022d028
+    fn: rasterio-0.19.1.tar.gz
+    url: https://pypi.python.org/packages/source/r/rasterio/rasterio-0.19.1.tar.gz
+    md5: 0926985f2dd9551feddd1737085cae59
+    #git_url: https://github.com/mapbox/rasterio.git
+    #git_tag: 0.19.1
+    #sha1: 0bd4b53a7f036a4631eaae8c6cd92f8f0d8799df
 
 build:
-  number: 0
+    number: 0
 
-  entry_points:
-    - rio = rasterio.rio.main:cli
+    entry_points:
+        - rio = rasterio.rio.main:cli
 
 requirements:
-  build:
-    - affine >=1.0
-    - cython >=0.20
-    - click
-    - cligj
-    - enum34
-    - gdal
-    - numpy >=1.8
-    - python
-    - setuptools
-
-  run:
-    - affine >=1.0
-    - click
-    - cligj
-    - enum34
-    - gdal
-    - numpy >=1.8
-    - python
+    build:
+        - python
+        - numpy >=1.8
+        - cython >=0.20
+        - gdal
+        - setuptools
+    run:
+        - python
+        - affine >=1.0
+        - cligj
+        - enum34
+        - numpy >=1.8
+        - snuggs >=1.2
+        - cython >=0.20
+        - gdal
 
 test:
-  imports:
-    - rasterio
+    imports:
+        - rasterio
 
 about:
-  home: https://github.com/mapbox/rasterio
-  license: BSD
+    home: https://github.com/mapbox/rasterio
+    license: BSD

--- a/snuggs/bld.bat
+++ b/snuggs/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed  --record record.txt
+if errorlevel 1 exit 1

--- a/snuggs/build.sh
+++ b/snuggs/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed  --record record.txt

--- a/snuggs/meta.yaml
+++ b/snuggs/meta.yaml
@@ -1,0 +1,34 @@
+package:
+  name: snuggs
+  version: "1.3.0"
+
+source:
+  fn: snuggs-1.3.0.tar.gz
+  url: https://pypi.python.org/packages/source/s/snuggs/snuggs-1.3.0.tar.gz
+  md5: e672ad353eb2f0a2f8a832e61b99ffb9
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - click
+    - numpy
+    - pyparsing
+
+  run:
+    - python
+    - click
+    - numpy
+    - pyparsing
+
+test:
+  imports:
+    - snuggs
+
+about:
+  home: https://github.com/mapbox/snuggs
+  license: MIT
+  summary: Snuggs are s-expressions for Numpy


### PR DESCRIPTION
0.19.1 (2015-03-30)
-------------------
- Add missing blockxsize, blockysize, tiled keywords (#301).

0.19.0 (2015-03-25)
-------------------
- New rio-calc command (#175).
- Added a file band shortcut to fillnodata() (#271).
- Added fillnodata() to rio-calc functions (#277).
- New approach to masking arrays on read that conforms more closely to GDAL's
  RFC 15 (#282, #284, #285).
- New read_masks() method (#284).
- Deprecation of read_mask() and read_band (#284).
- New affine transform factory functions from_origin(), from_bounds() (#287).
- Improve correctness of indexing and rio-merge logic (#288, #290).