### PR TITLE
Updated dateutil.

### DIFF
--- a/python-dateutil/bld.bat
+++ b/python-dateutil/bld.bat
@@ -1,1 +1,1 @@
-%PYTHON% setup.py install
+%PYTHON% setup.py install --single-version-externally-managed  --record record.txt

--- a/python-dateutil/build.sh
+++ b/python-dateutil/build.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.
+$PYTHON setup.py install --single-version-externally-managed  --record record.txt

--- a/python-dateutil/meta.yaml
+++ b/python-dateutil/meta.yaml
@@ -1,30 +1,27 @@
 package:
-  name: python-dateutil
-  version: !!str 2.2
+    name: python-dateutil
+    version: "2.4.2"
 
 source:
-  fn: python-dateutil-2.2.tar.gz
-  url: https://pypi.python.org/packages/source/p/python-dateutil/python-dateutil-2.2.tar.gz
-  md5: c1f654d0ff7e33999380a8ba9783fd5c
+    fn: python-dateutil-2.4.2.tar.gz
+    url: https://pypi.python.org/packages/source/p/python-dateutil/python-dateutil-2.4.2.tar.gz
+    md5: 4ef68e1c485b09e9f034e10473e5add2
 
 requirements:
-  build:
-    - python
-    - setuptools
-    - six
-
-  run:
-    - python
-    - six
+    build:
+        - python
+        - setuptools
+        - six
+    run:
+        - python
+        - six
 
 test:
-  # Python imports
-  imports:
-    - dateutil
-    - dateutil.zoneinfo
+    imports:
+        - dateutil
+        - dateutil.zoneinfo
 
 about:
-  home: http://labix.org/python-dateutil
-  license: BSD License
-  summary: 'Extensions to the standard Python datetime module'
-
+    home: http://labix.org/python-dateutil
+    license: BSD License
+    summary: 'Extensions to the standard Python datetime module'


### PR DESCRIPTION
Updated zoneinfo to 2015b.

- Fixed issue with parsing of tzstr on Python 2.7.x; tzstr will now be decoded if not a unicode type. gh #51 (lp:1331576), gh pr #55.
- Fix a parser issue where AM and PM tokens were showing up in fuzzy date stamps, triggering inappropriate errors. gh #56 (lp: 1428895), gh pr #63.
- Missing function "setcachsize" removed from zoneinfo all list by @ryanss, fixing an issue with wildcard imports of dateutil.zoneinfo. (gh pr #66).
- (PyPi only) Fix an issue with source distributions not including the test suite.