### PR TITLE
Updated click

### DIFF
--- a/click/bld.bat
+++ b/click/bld.bat
@@ -1,8 +1,2 @@
-"%PYTHON%" setup.py install
+"%PYTHON%" setup.py install --single-version-externally-managed  --record record.txt
 if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.

--- a/click/build.sh
+++ b/click/build.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.
+$PYTHON setup.py install --single-version-externally-managed  --record record.txt

--- a/click/meta.yaml
+++ b/click/meta.yaml
@@ -1,26 +1,26 @@
 package:
-  name: click
-  version: !!str 3.3
+    name: click
+    version: "4.0"
 
 source:
-  git_url: https://github.com/mitsuhiko/click.git
-  git_tag: 3.3
+    git_url: https://github.com/mitsuhiko/click.git
+    git_tag: 4.0
 
 build:
-  number: 0
+    number: 0
 
 requirements:
-  build:
-    - python
-    - setuptools
-  run:
-    - python
+    build:
+        - python
+        - setuptools
+    run:
+        - python
 
 test:
-  imports:
-    - click
+    imports:
+        - click
 
 about:
-  home: http://github.com/mitsuhiko/click
-  license:  BSD License
-  summary: 'A simple wrapper around optparse for powerful command line utilities.'
+    home: http://github.com/mitsuhiko/click
+    license:  BSD License
+    summary: 'A simple wrapper around optparse for powerful command line utilities.'


### PR DESCRIPTION
Version 4.0
-----------

(codename "zoom zoom", released on March 31st 2015)

- Added `color` parameters to lots of interfaces that directly or indirectly
  call into echoing.  This previously was always autodetection (with the
  exception of the `echo_via_pager` function).  Now you can forcefully
  enable or disable it, overriding the auto detection of Click.
- Added an `UNPROCESSED` type which does not perform any type changes which
  simplifies text handling on 2.x / 3.x in some special advanced usecases.
- Added `NoSuchOption` and `BadOptionUsage` exceptions for more generic
  handling of errors.
- Added support for handling of unprocessed options which can be useful in
  situations where arguments are forwarded to underlying tools.
- Added `max_content_width` parameter to the context which can be used to
  change the maximum width of help output.  By default Click will not format
  content for more than 80 characters width.
- Added support for writing prompts to stderr.
- Fix a bug when showing the default for multiple arguments.
- Added support for custom subclasses to `option` and `argument`.
- Fix bug in ``clear()`` on Windows when colorama is installed.
- Reject ``nargs=-1`` for options properly.  Options cannot be variadic.
- Fixed an issue with bash completion not working properly for commands with
  non ASCII characters or dashes.
- Added a way to manually update the progressbar.
- Changed the formatting of missing arguments.  Previously the internal
  argument name was shown in error messages, now the metavar is shown if
  passed.  In case an automated metavar is selected, it's stripped of
  extra formatting first.