### PR TITLE
Updated coveralls

### DIFF
--- a/coveralls/bld.bat
+++ b/coveralls/bld.bat
@@ -1,8 +1,2 @@
-"%PYTHON%" setup.py install
+"%PYTHON%" setup.py install --single-version-externally-managed  --record record.txt
 if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.

--- a/coveralls/build.sh
+++ b/coveralls/build.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.
+$PYTHON setup.py install --single-version-externally-managed  --record record.txt

--- a/coveralls/meta.yaml
+++ b/coveralls/meta.yaml
@@ -1,40 +1,38 @@
 package:
-  name: coveralls
-  version: !!str 0.5
+    name: coveralls
+    version: "1.0a2"
 
 source:
-  fn: coveralls-0.5.zip
-  url: https://pypi.python.org/packages/source/c/coveralls/coveralls-0.5.zip
-  md5: 9830c7ec568b2ffde62e9dabbcecfbba
+    fn: coveralls-1.0a2.tar.gz
+    url: https://pypi.python.org/packages/source/c/coveralls/coveralls-1.0a2.tar.gz
+    md5: 678eb7fdd3d477a4d9d0cacbffe88ee2
 
 build:
-  entry_points:
-    - coveralls = coveralls.cli:main
-  number: 0
+    number: 0
+    entry_points:
+        - coveralls = coveralls.cli:main
 
 requirements:
-  build:
-    - python
-    - setuptools
-    - pyyaml >=3.10
-    - docopt >=0.6.1
-    - coverage >=3.6,<3.999
-    - requests >=1.0.0
-  run:
-    - python
-    - pyyaml >=3.10
-    - docopt >=0.6.1
-    - coverage >=3.6,<3.999
-    - requests >=1.0.0
+    build:
+        - python
+        - setuptools
+        - docopt >=0.6.1
+        - coverage >=3.6
+        - requests >=1.0.0
+    run:
+        - python
+        - setuptools
+        - docopt >=0.6.1
+        - coverage >=3.6
+        - requests >=1.0.0
 
 test:
-  imports:
-    - coveralls
-
-  commands:
-    - coveralls --help
+    imports:
+        - coveralls
+    commands:
+        - coveralls --help
 
 about:
-  home: http://github.com/coagulant/coveralls-python
-  license: MIT License
-  summary: 'Show coverage stats online via coveralls.io'
+    home: http://github.com/coagulant/coveralls-python
+    license: MIT License
+    summary: 'Show coverage stats online via coveralls.io'


### PR DESCRIPTION
1.0a2 (2015-02-19)
* Fix latest alpha coverage.py support
* Remove erroneous warning message when writing output to a file

1.0a1 (2015-02-19)
* **Backwards incompatible**: make pyyaml optional. If you're using .coveralls.yml, make sure to install coveralls[yaml]
* Coverage 4 alpha support
* Allow debug and output options to work without repo_token
* Fix merge command for python 3.X