### PR TITLE
Updated flopy

### DIFF
--- a/flopy/bld.bat
+++ b/flopy/bld.bat
@@ -1,8 +1,2 @@
-"%PYTHON%" setup.py install
+"%PYTHON%" setup.py install --single-version-externally-managed  --record record.txt
 if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.

--- a/flopy/build.sh
+++ b/flopy/build.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.
+$PYTHON setup.py install --single-version-externally-managed  --record record.txt

--- a/flopy/meta.yaml
+++ b/flopy/meta.yaml
@@ -1,25 +1,26 @@
 package:
-  name: flopy
-  version: !!str 2.0
+    name: flopy
+    version: "3.1.1"
 
 source:
-  svn_url: http://flopy.googlecode.com/svn/trunk/
+    git_url: https://github.com/modflowpy/flopy.git
+    git_tag: 3.1.1
 
 build:
-  number: 0
+    number: 0
 
 requirements:
-  build:
-    - python
-    - setuptools
-    - numpy
-    - matplotlib
-  run:
-    - python
-    - numpy
-    - matplotlib
+    build:
+        - python
+        - setuptools
+        - numpy
+        - matplotlib
+    run:
+        - python
+        - numpy
+        - matplotlib
 
 about:
-  home: https://code.google.com/p/flowpy/
-  license: BSD
-  summary: 'scripts to run MODFLOW, MT3D, SWI and SEAWAT'
+    home: https://code.google.com/p/flowpy/
+    license: BSD
+    summary: 'scripts to run MODFLOW, MT3D, SWI and SEAWAT'


### PR DESCRIPTION
(Fix #167 )

# Version 3.1

- FloPy3 now supports some simple mapping and cross-section capabilities through the flopy.plot submodule. See the notebook flopy3_MapExample.

- Full support for all Output Control (OC) options including DDREFERENCE, SAVE IBOUND, and layer lists. All Output Control Input is specified using words. Output Control Input using numeric codes is still available in the ModflowOc88 class. The ModflowOc88 class is currently deprecated and no longer actively maintained.

- Added support for standard MULT package FUNCTION and EXPRESSION functionality are supported. MODFLOW parameters are not supported in write() methods.

# Version 3.0

- FloPy3 is significantly different from FloPy2 (previously hosted on googlecode). The main changes are:

- FloPy3 is fully zero-based. This means that layers, rows and columns start counting at zero. The reason for this is consistency. Arrays are zero-based by default in Python, so it was confusing to have a mix.

- Input for packages that take layer, row, column, data input (like the wel or ghb package) has changed and is much more flexible now. See the notebook flopy3boundaries

- Input for the MT3DMS Source/Sink Mixing (SSM) Package has been modified to be consistent with the new MODFLOW boundary package input and is more flexible than previous versions of FloPy. See the notebook flopy3ssm

- Support for use of EXTERNAL and OPEN/CLOSE array specifiers has been improved.

- load() methods have been developed for all of the standard MODFLOW packages and a few less used packages (e.g. SWI2).

- MODFLOW parameter support has been added to the load() methods. MULT, PVAL, and ZONE packages are now supported and parameter data are converted to arrays in the load() methods. MODFLOW parameters are not supported in write() methods.