### PR TITLE
Updated isodate

### DIFF
--- a/isodate/bld.bat
+++ b/isodate/bld.bat
@@ -1,8 +1,2 @@
-"%PYTHON%" setup.py install
+"%PYTHON%" setup.py install --single-version-externally-managed  --record record.txt
 if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.

--- a/isodate/build.sh
+++ b/isodate/build.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.
+$PYTHON setup.py install --single-version-externally-managed  --record record.txt

--- a/isodate/meta.yaml
+++ b/isodate/meta.yaml
@@ -1,28 +1,28 @@
 package:
-  name: isodate
-  version: !!str 0.4.9
+    name: isodate
+    version: "0.5.1"
 
 source:
-  fn: isodate-0.4.9.tar.gz
-  url: https://pypi.python.org/packages/source/i/isodate/isodate-0.4.9.tar.gz
-  md5: dd7399f024637f5e59260f59e6af6af4
+    fn: isodate-0.5.1.tar.gz
+    url: https://pypi.python.org/packages/source/i/isodate/isodate-0.5.1.tar.gz
+    md5: 22232a6b0f5d320610ae45722c1b9542
 
 build:
-  number: 0
+    number: 0
 
 requirements:
-  build:
-    - python
-    - setuptools
-  run:
-    - python
+    build:
+        - python
+        - setuptools
+    run:
+        - python
 
 test:
-  imports:
-    - isodate.tests
-    - isodate
+    imports:
+        - isodate
+        - isodate.tests
 
 about:
-  home: http://cheeseshop.python.org/pypi/isodate
-  license: BSD License
-  summary: 'An ISO 8601 date/time/duration parser and formatter'
+    home: http://cheeseshop.python.org/pypi/isodate
+    license: BSD License
+    summary: 'An ISO 8601 date/time/duration parser and formatter'


### PR DESCRIPTION
0.5.1 (2014-11-07)
------------------

- fixed pickling of Duration objects
- raise ISO8601Error when there is no 'T' separator in datetime strings (Adrian Coveney)


0.5.0 (2014-02-23)
------------------

- ISO8601Error are subclasses of ValueError now (Michael Hrivnak)
- improve compatibility across various python variants and versions
- raise exceptions when using fractional years and months in date
  maths with durations
- renamed method todatetime on Duraction objects to totimedelta