### PR TITLE
Updated rdflib.

### DIFF
--- a/rdflib/bld.bat
+++ b/rdflib/bld.bat
@@ -1,3 +1,4 @@
 pip install SPARQLWrapper
-"%PYTHON%" setup.py install
+
+"%PYTHON%" setup.py install  --single-version-externally-managed  --record record.txt
 if errorlevel 1 exit 1

--- a/rdflib/build.sh
+++ b/rdflib/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 pip install SPARQLWrapper
-$PYTHON setup.py install
+
+$PYTHON setup.py install --single-version-externally-managed  --record record.txt

--- a/rdflib/meta.yaml
+++ b/rdflib/meta.yaml
@@ -1,51 +1,50 @@
 package:
-   name: rdflib
-   version: "4.1.2"
+    name: rdflib
+    version: "4.2.0"
 
 source:
-   fn: rdflib-4.1.2.tar.gz
-   url: https://pypi.python.org/packages/source/r/rdflib/rdflib-4.1.2.tar.gz
-   md5: a356cf3bdfe1a72d240d151ce5662b84
+    fn: rdflib-4.2.0.tar.gz
+    url: https://pypi.python.org/packages/source/r/rdflib/rdflib-4.2.0.tar.gz
+    md5: ac6f02229bfb1882d743de496268f8d8
 
 build:
-   number: 0
-   entry_points:
-   - rdfpipe = rdflib.tools.rdfpipe:main
-   - csv2rdf = rdflib.tools.csv2rdf:main
-   - rdf2dot = rdflib.tools.rdf2dot:main
-   - rdfs2dot = rdflib.tools.rdfs2dot:main
-   - rdfgraphisomorphism = rdflib.tools.graphisomorphism:main
+    number: 0
+    entry_points:
+        - rdfpipe = rdflib.tools.rdfpipe:main
+        - csv2rdf = rdflib.tools.csv2rdf:main
+        - rdf2dot = rdflib.tools.rdf2dot:main
+        - rdfs2dot = rdflib.tools.rdfs2dot:main
+        - rdfgraphisomorphism = rdflib.tools.graphisomorphism:main
 
 requirements:
-  build:
-   - python
-   - setuptools
-   - pip
-   - isodate
-   - pyparsing
-   # Using pip in build.sh/bld.bat to avoid circular dependency.
-   # - sparqlwrapper
-   - html5lib
-   - six
-
-  run:
-   - python
-   - setuptools
-   - isodate
-   - pyparsing
-   # - sparqlwrapper
-   - html5lib
-   - six
+    build:
+        - python
+        - setuptools
+        - pip
+        - isodate
+        - pyparsing
+        # NOTE: Using pip in build.sh/bld.bat to avoid circular dependency.
+        # - sparqlwrapper
+        - html5lib
+        - six
+    run:
+        - python
+        - setuptools
+        - isodate
+        - pyparsing
+        # NOTE: Using pip in build.sh/bld.bat to avoid circular dependency.
+        # - sparqlwrapper
+        - html5lib
+        - six
 
 test:
-   imports:
-   - rdflib
-   - rdflib.namespace
-
-   commands:
-   - rdfpipe --help
+    imports:
+        - rdflib
+        - rdflib.namespace
+    commands:
+        - rdfpipe --help
 
 about:
-  home: https://github.com/RDFLib/rdflib
-  license: BSD License
-  summary: 'RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information'
+    home: https://github.com/RDFLib/rdflib
+    license: BSD License
+    summary: 'RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information'


### PR DESCRIPTION
2015/02/19 RELEASE 4.2.0
========================

This is a new minor version of RDFLib including a handful of new features:

* Supporting N-Triples 1.1 syntax using UTF-8 encoding
  [#447](https://github.com/RDFLib/rdflib/pull/447),
  [#449](https://github.com/RDFLib/rdflib/pull/449),
  [#400](https://github.com/RDFLib/rdflib/issues/400)
* Graph comparison now really works using RGDA1 (RDF Graph Digest Algorithm 1)
  [#441](https://github.com/RDFLib/rdflib/pull/441)
  [#385](https://github.com/RDFLib/rdflib/issues/385)
* More graceful degradation than simple crashing for unicode chars > 0xFFFF on
  narrow python builds. Parsing such characters will now work, but issue a
  UnicodeWarning. If you run `python -W all` you will already see a warning on
  `import rdflib` will show a warning (ImportWarning).
  [#453](https://github.com/RDFLib/rdflib/pull/453),
  [#454](https://github.com/RDFLib/rdflib/pull/454)
* URLInputSource now supports json-ld
  [#425](https://github.com/RDFLib/rdflib/pull/425)
* SPARQLStore is now graph aware
  [#401](https://github.com/RDFLib/rdflib/pull/401),
  [#402](https://github.com/RDFLib/rdflib/pull/402)
* SPARQLStore now uses SPARQLWrapper for updates
  [#397](https://github.com/RDFLib/rdflib/pull/397)
* Certain logging output is immediately shown in interactive mode
  [#414](https://github.com/RDFLib/rdflib/pull/414)
* Python 3.4 fully supported
  [#418](https://github.com/RDFLib/rdflib/pull/418)

Minor enhancements & bugs fixed:
--------------------------------

* Fixed double invocation of 2to3
  [#437](https://github.com/RDFLib/rdflib/pull/437)
* PyRDFa parser missing brackets
  [#434](https://github.com/RDFLib/rdflib/pull/434)
* Correctly handle \uXXXX and \UXXXXXXXX escapes in n3 files
  [#426](https://github.com/RDFLib/rdflib/pull/426)
* Logging cleanups and keeping it on stderr
  [#420](https://github.com/RDFLib/rdflib/pull/420)
  [#414](https://github.com/RDFLib/rdflib/pull/414)
  [#413](https://github.com/RDFLib/rdflib/issues/413)
* n3: allow @base URI to have a trailing '#'
  [#407](https://github.com/RDFLib/rdflib/pull/407)
  [#379](https://github.com/RDFLib/rdflib/issues/379)
* microdata: add file:// to base if it's a filename so rdflib can parse its own
  output
  [#406](https://github.com/RDFLib/rdflib/pull/406)
  [#403](https://github.com/RDFLib/rdflib/issues/403)
* TSV Results parse skips empty bindings in result
  [#390](https://github.com/RDFLib/rdflib/pull/390)
* fixed accidental test run due to name
  [#389](https://github.com/RDFLib/rdflib/pull/389)
* Bad boolean list serialization to Turtle & fixed ambiguity between
  Literal(False) and None
  [#387](https://github.com/RDFLib/rdflib/pull/387)
  [#382](https://github.com/RDFLib/rdflib/pull/382)
* Current version number & PyPI link in README.md
  [#383](https://github.com/RDFLib/rdflib/pull/383)