### PR TITLE
Sci-wms repo and recipe update.

### DIFF
--- a/djangorestframework/bld.bat
+++ b/djangorestframework/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/djangorestframework/build.sh
+++ b/djangorestframework/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/djangorestframework/meta.yaml
+++ b/djangorestframework/meta.yaml
@@ -1,0 +1,32 @@
+package:
+    name: djangorestframework
+    version: "3.1.1"
+
+source:
+    fn: djangorestframework-3.1.1.tar.gz
+    url: https://pypi.python.org/packages/source/d/djangorestframework/djangorestframework-3.1.1.tar.gz
+    md5: d0f6aa82d49e63faebaadfc089e5e80b
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+
+test:
+    imports:
+        - rest_framework
+        - rest_framework.authtoken
+        - rest_framework.authtoken.migrations
+        - rest_framework.authtoken.south_migrations
+        - rest_framework.templatetags
+        - rest_framework.utils
+
+about:
+    home: http://www.django-rest-framework.org
+    license: BSD License
+    summary: 'Web APIs for Django, made easy.'

--- a/sci-wms-deps/meta.yaml
+++ b/sci-wms-deps/meta.yaml
@@ -31,7 +31,7 @@ requirements:
         - pyugrid
         - basemap
         - gunicorn >=0.13.4
-        - setproctitle
+        - setproctitle  # [not win]
         - tornado
         - greenlet
         - gevent

--- a/sci-wms-deps/meta.yaml
+++ b/sci-wms-deps/meta.yaml
@@ -1,38 +1,44 @@
 package:
-  name: sci-wms-deps
-  version: !!str 0.1.0
+    name: sci-wms-deps
+    version: "0.0.2"
 source:
-  git_url: https://github.com/kwilcox/sci-wms.git
-  git_tag: stable
+    git_url: https://github.com/sci-wms/sci-wms.git
+    git_tag: 0.0.2
 
 build:
-  number: 0
-  preserve_egg_dir: True
+    number: 0
+    preserve_egg_dir: True
+
+build:
+    number: 0
 
 requirements:
-  build:
-
-  run:
-    - python
-    - django
-    - shapely
-    - numpy
-    - greenlet
-    - gevent
-    - gunicorn
-    - python-dateutil
-    - matplotlib
-    - netcdf4
-    - rtree 0.7*
-    - south
-    - jsonfield
-    - south
-    - basemap
-    - pyugrid
-    - pytz
-    - pyproj
+    build:
+        - python
+    run:
+        - python
+        - numpy
+        - django >=1.7,<1.8
+        - shapely
+        - python-dateutil
+        - matplotlib
+        - netcdf4
+        - rtree ==0.7*
+        - south
+        - jsonfield
+        - pytz
+        - djangorestframework
+        - pyugrid
+        - basemap
+        - gunicorn >=0.13.4
+        - setproctitle
+        - tornado
+        - greenlet
+        - gevent
+        - south
+        - pyproj
 
 about:
-  home: https://github.com/asa-science-open.github.io/sci-wms
-  license: GNU General Public License v3 (GPLv3)
-  summary: 'A Python WMS service for geospatial grid and mesh data'
+    home: https://github.com/sci-wms/sci-wms
+    license: GNU General Public License v3 (GPLv3)
+    summary: 'A Python WMS service for geospatial gridded data'

--- a/setproctitle/bld.bat
+++ b/setproctitle/bld.bat
@@ -1,2 +1,0 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1

--- a/setproctitle/bld.bat
+++ b/setproctitle/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/setproctitle/build.sh
+++ b/setproctitle/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/setproctitle/meta.yaml
+++ b/setproctitle/meta.yaml
@@ -1,0 +1,26 @@
+package:
+    name: setproctitle
+    version: "1.1.8"
+
+source:
+    fn: setproctitle-1.1.8.tar.gz
+    url: https://pypi.python.org/packages/source/s/setproctitle/setproctitle-1.1.8.tar.gz
+    md5: 728f4c8c6031bbe56083a48594027edd
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+    run:
+        - python
+
+test:
+    imports:
+        - setproctitle
+
+about:
+    home: http://code.google.com/p/py-setproctitle/
+    license: BSD License
+    summary: 'A library to allow customization of the process title.'


### PR DESCRIPTION
This PR closes #173.

@rsignell-usgs and @kwilcox I would like to:
- [ ] Write a script to "copy" `sci-wms` to a working directory and drop the name  `sci-wms-deps`
- [ ] Run a test on that working directory (like: `python manage.py test`).

What do you think?  Worth pursuing? This script would be something like `sci-wms [new|deploy|help|serve]` format.