### PR TITLE
Added oct2py

### DIFF
--- a/oct2py/bld.bat
+++ b/oct2py/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/oct2py/build.sh
+++ b/oct2py/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/oct2py/meta.yaml
+++ b/oct2py/meta.yaml
@@ -1,0 +1,34 @@
+package:
+  name: oct2py
+  version: "3.1.0"
+
+source:
+  fn: oct2py-3.1.0.tar.gz
+  url: https://pypi.python.org/packages/source/o/oct2py/oct2py-3.1.0.tar.gz
+  md5: 12fcdcdb95f3bf6d7ebd04a382ce9242
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - setuptools
+    - numpy >=1.7.1
+    - scipy >=0.12
+    - ipython
+
+test:
+  imports:
+    - oct2py
+    - oct2py.tests
+    - oct2py.ipython
+    - oct2py.ipython.tests
+
+about:
+  home: http://github.com/blink1073/oct2py
+  license: MIT License
+  summary: 'Python to GNU Octave bridge --> run m-files from python.'


### PR DESCRIPTION
This package relies on the system installed octave.  Creating a conda package for octave is a little bit tricky. 