### PR TITLE
Added Linux find_library patch

### DIFF
--- a/rtree/find_libray.patch
+++ b/rtree/find_libray.patch
@@ -1,0 +1,54 @@
+--- rtree/core.py.orig	2014-11-03 00:20:21.000000000 -0300
++++ rtree/core.py	2015-04-25 15:15:45.594333729 -0300
+@@ -65,45 +65,14 @@
+     
+ 
+ if os.name == 'nt':
+-
+-    def _load_library(dllname, loadfunction, dllpaths=('', )):
+-        """Load a DLL via ctypes load function. Return None on failure.
+-
+-        Try loading the DLL from the current package directory first,
+-        then from the Windows DLL search path.
+-
+-        """
+-        try:
+-            dllpaths = (os.path.abspath(os.path.dirname(__file__)),
+-                        ) + dllpaths
+-        except NameError:
+-            pass # no __file__ attribute on PyPy and some frozen distributions
+-        for path in dllpaths:
+-            if path:
+-                # temporarily add the path to the PATH environment variable
+-                # so Windows can find additional DLL dependencies.
+-                try:
+-                    oldenv = os.environ['PATH']
+-                    os.environ['PATH'] = path + ';' + oldenv
+-                except KeyError:
+-                    oldenv = None
+-            try:
+-                return loadfunction(os.path.join(path, dllname))
+-            except (WindowsError, OSError):
+-                pass
+-            finally:
+-                if path and oldenv is not None:
+-                    os.environ['PATH'] = oldenv
+-        return None
+-
+-    rt = _load_library('spatialindex_c.dll', ctypes.cdll.LoadLibrary)
+-    if not rt:
+-        raise OSError("could not find or load spatialindex_c.dll")
+-
++    rt = os.path.join(sys.prefix, "Library", "bin", "spatialindex_c.dll")
+ elif os.name == 'posix':
+     platform = os.uname()[0]
+-    lib_name = find_library('spatialindex_c')
+-    rt = ctypes.CDLL(lib_name)
++    if platform == 'Linux':
++        lib_name = 'libspatialindex_c.so'
++    else:
++        lib_name = 'libspatialindex_c.dylib'
++    rt = ctypes.CDLL(os.path.join(sys.prefix, 'lib', lib_name))
+ else:
+     raise RTreeError('Unsupported OS "%s"' % os.name)
+ 

--- a/rtree/meta.yaml
+++ b/rtree/meta.yaml
@@ -5,10 +5,12 @@ package:
 source:
   git_url: https://github.com/Toblerity/rtree.git
   git_tag: 0.8.1
+  patches:
+    - find_libray.patch
 
 build:
   preserve_egg_dir: True
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
This patch hard-codes the conda lib patch to ensure the module will find the conda version of the c-lib and not a system c-lib.  The same must be done for OSX and Windows.

Closes #184