### PR TITLE
Updated ulmo

### DIFF
--- a/ulmo/bld.bat
+++ b/ulmo/bld.bat
@@ -1,8 +1,2 @@
-"%PYTHON%" setup.py install
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.

--- a/ulmo/build.sh
+++ b/ulmo/build.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/ulmo/meta.yaml
+++ b/ulmo/meta.yaml
@@ -1,68 +1,67 @@
 package:
-  name: ulmo
-  version: !!str 0.7.5
+    name: ulmo
+    version: "0.7.6"
 
 source:
-  git_url: https://github.com/ulmo-dev/ulmo.git
-  git_tag: v0.7.5
+    git_url: https://github.com/ulmo-dev/ulmo.git
+    git_tag: v0.7.6
 
 build:
-  number: 0
+    number: 0
 
 requirements:
-  build:
-    - python
-    - setuptools
-    - appdirs
-    - beautifulsoup4
-    - isodate
-    - lxml
-    - mock
-    - numpy
-    - pandas
-    - requests
-    - suds
-    - pytables
-
-  run:
-    - python
-    - appdirs
-    - beautifulsoup4
-    - isodate
-    - lxml
-    - mock
-    - numpy
-    - pandas
-    - requests
-    - suds
-    - pytables
+    build:
+        - python
+        - setuptools
+        - appdirs
+        - beautifulsoup4
+        - isodate
+        - lxml
+        - mock
+        - numpy
+        - pandas
+        - requests
+        - suds
+        - pytables
+    run:
+        - python
+        - appdirs
+        - beautifulsoup4
+        - isodate
+        - lxml
+        - mock
+        - numpy
+        - pandas
+        - requests
+        - suds
+        - pytables
+        - geojson
 test:
-  # Python imports
-  imports:
-    - ulmo.usgs.nwis
-    - ulmo.cdec.historical
-    - ulmo.util
-    - ulmo.waterml
-    - ulmo.ncdc
-    - ulmo.cpc
-    - ulmo.cuahsi
-    - ulmo.cpc.drought
-    - ulmo.ncdc.gsod
-    - ulmo.usgs.eddn
-    - ulmo.ncdc.cirs
-    - ulmo.twc
-    - ulmo.cuahsi.his_central
-    - ulmo.usgs
-    - ulmo.usace.rivergages
-    - ulmo
-    - ulmo.ncdc.ghcn_daily
-    - ulmo.usace.swtwc
-    - ulmo.twc.kbdi
-    - ulmo.cuahsi.wof
-    - ulmo.usace
-    - ulmo.cdec
+    imports:
+        - ulmo.usgs.nwis
+        - ulmo.cdec.historical
+        - ulmo.util
+        - ulmo.waterml
+        - ulmo.ncdc
+        - ulmo.cpc
+        - ulmo.cuahsi
+        - ulmo.cpc.drought
+        - ulmo.ncdc.gsod
+        - ulmo.usgs.eddn
+        - ulmo.ncdc.cirs
+        - ulmo.twc
+        - ulmo.cuahsi.his_central
+        - ulmo.usgs
+        - ulmo.usace.rivergages
+        - ulmo
+        - ulmo.ncdc.ghcn_daily
+        - ulmo.usace.swtwc
+        - ulmo.twc.kbdi
+        - ulmo.cuahsi.wof
+        - ulmo.usace
+        - ulmo.cdec
 
 about:
-  home: https://github.com/ulmo-dev/ulmo/
-  license: BSD License
-  summary: 'Clean, simple and fast access to public hydrology and climatology data'
+    home: https://github.com/ulmo-dev/ulmo/
+    license: BSD License
+    summary: 'Clean, simple and fast access to public hydrology and climatology data'


### PR DESCRIPTION
**0.7.6 (released 2015-04-27)**
- fixed ncdc.gsod services to use new station list over depreciated list (thanks Victor)
- added USGS National Elevation Dataset (NED) raster service
- added USGS Earth Resources Observation Systems (EROS) raster services
- allow passthrough of extra kwargs for USGS NWIS services