### PR TITLE
Re-build cartopy with proj4-4.9.1

### DIFF
--- a/cartopy/meta.yaml
+++ b/cartopy/meta.yaml
@@ -10,7 +10,7 @@ source:
     - cartopy.win.patch  # [win]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -28,7 +28,6 @@ requirements:
     - owslib
     - pyshp
     - pyepsg
-  
   run:
     - python
     - six


### PR DESCRIPTION
@rsignell-usgs If a user install the latest proj4 with the current cartopy s/he may get an error like

```python
ImportError: libproj.so.0: cannot open shared object file: No such file or directory
``` 

Re-building it against latest `proj4` should solve the issue.