### PR TITLE
Using pillow instead of PIL

### DIFF
--- a/cartopy/meta.yaml
+++ b/cartopy/meta.yaml
@@ -10,7 +10,7 @@ source:
     - cartopy.win.patch  # [win]
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -33,7 +33,7 @@ requirements:
     - six
     - mock
     - nose
-    - pil
+    - pillow
     - owslib
     - numpy
     - proj4


### PR DESCRIPTION
PIL is deprecated and its use is holding back some updates when trying: `conda update --all`.