### PR TITLE
Updates rasterio to v0.21.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
     - python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 2 --without-obvci && source ~/miniconda/bin/activate root
     # Config conda channels.
     - conda config --set show_channel_urls True
-    - conda config --add channels http://conda.binstar.org/ocefpaf
+    - conda config --add channels http://conda.binstar.org/ioos
     # Install Obvious-CI.
     - conda install -c http://conda.binstar.org/ioos/channel/main --yes --quiet obvious-ci
     - obvci_install_conda_build_tools.py

--- a/cartopy/meta.yaml
+++ b/cartopy/meta.yaml
@@ -10,7 +10,7 @@ source:
     - cartopy.win.patch  # [win]
 
 build:
-  number: 2
+  number: 0
 
 requirements:
   build:

--- a/geos/meta.yaml
+++ b/geos/meta.yaml
@@ -1,21 +1,21 @@
 package:
-  name: geos
-  version: "3.4.2"
+    name: geos
+    version: "3.4.2"
+
 source:
-  fn:  geos-3.4.2.tar.bz2
-  url: http://download.osgeo.org/geos/geos-3.4.2.tar.bz2
-  patches:
-    - cmake.win.patch  # [win]
+    fn:  geos-3.4.2.tar.bz2
+    url: http://download.osgeo.org/geos/geos-3.4.2.tar.bz2
+    patches:
+        - cmake.win.patch  # [win]
 
 build:
-  number: 0  # [win]
-  number: 0  # [not win]
+    number: 0
 
 requirements:
-  build:
-
-  run:
+    build:
+    run:
 
 about:
-  home: http://trac.osgeo.org/geos/
-  summary: 'Geometry Engine - Open Source'
+    home: http://trac.osgeo.org/geos/
+    license: LGPL
+    summary: 'Geometry Engine - Open Source'

--- a/proj4/meta.yaml
+++ b/proj4/meta.yaml
@@ -3,7 +3,7 @@ package:
     version: "4.9.1"
 
 build:
-    number: 0
+    number: 1
 
 source:
     fn:  proj-4.9.1.tar.gz

--- a/rasterio/meta.yaml
+++ b/rasterio/meta.yaml
@@ -1,14 +1,11 @@
 package:
     name: rasterio
-    version: "0.19.1"
+    version: "0.21"
 
 source:
-    fn: rasterio-0.19.1.tar.gz
-    url: https://pypi.python.org/packages/source/r/rasterio/rasterio-0.19.1.tar.gz
-    md5: 0926985f2dd9551feddd1737085cae59
-    #git_url: https://github.com/mapbox/rasterio.git
-    #git_tag: 0.19.1
-    #sha1: 0bd4b53a7f036a4631eaae8c6cd92f8f0d8799df
+    fn: rasterio-0.21.0.tar.gz
+    url: https://pypi.python.org/packages/source/r/rasterio/rasterio-0.21.0.tar.gz
+    md5: a3b32d218b28624af4f3aabab647a915
 
 build:
     number: 0
@@ -40,3 +37,4 @@ test:
 about:
     home: https://github.com/mapbox/rasterio
     license: BSD
+    summary: 'Rasterio reads and writes geospatial raster datasets'

--- a/rasterio/meta.yaml
+++ b/rasterio/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: rasterio
-    version: "0.21"
+    version: "0.22"
 
 source:
-    fn: rasterio-0.21.0.tar.gz
-    url: https://pypi.python.org/packages/source/r/rasterio/rasterio-0.21.0.tar.gz
-    md5: a3b32d218b28624af4f3aabab647a915
+    fn: rasterio-0.22.0.tar.gz
+    url: https://pypi.python.org/packages/source/r/rasterio/rasterio-0.22.0.tar.gz
+    md5: a67e9af49e5c15089c285d617c7351c4
 
 build:
     number: 0

--- a/shapely/meta.yaml
+++ b/shapely/meta.yaml
@@ -1,34 +1,34 @@
 package:
-  name: shapely
-  version: 1.5.8dev0
+    name: shapely
+    version: 1.5.8dev0
 
 source:
-  git_url: https://github.com/Toblerity/Shapely.git
-  git_tag: 2212deb2105d380345c9b558f8f4c3d3be903496
-  patches:
-    - geos_c.win.patch      # [win]
+    git_url: https://github.com/Toblerity/Shapely.git
+    git_tag: 2212deb2105d380345c9b558f8f4c3d3be903496
+    patches:
+        - geos_c.win.patch      # [win]
 
 build:
-  number: 0
+    number: 0
 
 requirements:
-  build:
-    - python
-    - geos >=3.4
-    - cython
-    - numpy
-  run:
-    - python
-    - geos
-    - numpy
+    build:
+        - python
+        - geos >=3.4
+        - cython
+        - numpy
+    run:
+        - python
+        - geos >=3.4
+        - numpy
 
 test:
-  imports:
-    - shapely
-    - shapely.speedups._speedups
-    - shapely.vectorized._vectorized
+    imports:
+        - shapely
+        - shapely.speedups._speedups
+        - shapely.vectorized._vectorized
 
 about:
-  home: https://github.com/Toblerity/Shapely
-  license: BSD
-  summary: 'Python package for manipulation and analysis of geometric objects in the Cartesian plane'
+    home: https://github.com/Toblerity/Shapely
+    license: BSD
+    summary: 'Python package for manipulation and analysis of geometric objects in the Cartesian plane'


### PR DESCRIPTION
Changes
=======

0.21.0 (2015-04-22)
-------------------
- New rio-mask command (#323).
- Masking bug fix for rio-shapes (#335).
- Addition of single valued nodata property to be used instead of nodatavals
  (#329).

0.20.0 (2015-04-08)
-------------------
- Switch read() default to masked=False (#300, #317).
- Fix documentation of masking throughout module (#305).
- Remove option for in place nodata filling (#309).
- Enhancements for valid data footprint extraction in rio-shapes (#316, #318).