### PR TITLE
Changing mplleaflet master -> PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
     - python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 2 --without-obvci && source ~/miniconda/bin/activate root
     # Config conda channels.
     - conda config --set show_channel_urls True
-    - conda config --add channels http://conda.binstar.org/ocefpaf
+    - conda config --add channels http://conda.binstar.org/ioos
     # Install Obvious-CI.
     - conda install -c http://conda.binstar.org/ioos/channel/main --yes --quiet obvious-ci
     - obvci_install_conda_build_tools.py

--- a/cartopy/meta.yaml
+++ b/cartopy/meta.yaml
@@ -10,7 +10,7 @@ source:
     - cartopy.win.patch  # [win]
 
 build:
-  number: 2
+  number: 0
 
 requirements:
   build:

--- a/geos/meta.yaml
+++ b/geos/meta.yaml
@@ -1,21 +1,21 @@
 package:
-  name: geos
-  version: "3.4.2"
+    name: geos
+    version: "3.4.2"
+
 source:
-  fn:  geos-3.4.2.tar.bz2
-  url: http://download.osgeo.org/geos/geos-3.4.2.tar.bz2
-  patches:
-    - cmake.win.patch  # [win]
+    fn:  geos-3.4.2.tar.bz2
+    url: http://download.osgeo.org/geos/geos-3.4.2.tar.bz2
+    patches:
+        - cmake.win.patch  # [win]
 
 build:
-  number: 0  # [win]
-  number: 0  # [not win]
+    number: 0
 
 requirements:
-  build:
-
-  run:
+    build:
+    run:
 
 about:
-  home: http://trac.osgeo.org/geos/
-  summary: 'Geometry Engine - Open Source'
+    home: http://trac.osgeo.org/geos/
+    license: LGPL
+    summary: 'Geometry Engine - Open Source'

--- a/mplleaflet/bld.bat
+++ b/mplleaflet/bld.bat
@@ -1,8 +1,1 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.
+"%PYTHON%" setup.py install --single-version-externally-managed  --record record.txt

--- a/mplleaflet/build.sh
+++ b/mplleaflet/build.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.
+$PYTHON setup.py install --single-version-externally-managed  --record record.txt

--- a/mplleaflet/meta.yaml
+++ b/mplleaflet/meta.yaml
@@ -1,32 +1,30 @@
 package:
-  name: mplleaflet
-
-  version: !!str 0.0.1
+    name: mplleaflet
+    version: "0.0.1"
 
 source:
-  git_url: https://github.com/jwass/mplleaflet/
-  git_tag: master
+    fn: mplleaflet-0.0.1.tar.gz
+    url: https://pypi.python.org/packages/source/m/mplleaflet/mplleaflet-0.0.1.tar.gz
+    md5: 5911765b46b9e6d339ad8b9917b84c7e
 
 build:
-  number: 0
+    number: 1
 
 
 requirements:
-  build:
-    - python
-    - setuptools
-
-  run:
-    - python
-    - jinja2
-    - mplexporter
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+        - jinja2
+        - mplexporter
 
 test:
-  # Python imports
-  imports:
-    - mplleaflet
+    imports:
+        - mplleaflet
 
 about:
-  home: https://github.com/jwass/mplleaflet
-  license: BSD 3-clause
-  summary: 'Convert Matplotlib plots into Leaflet web maps'
+    home: https://github.com/jwass/mplleaflet
+    license: BSD 3-clause
+    summary: 'Convert Matplotlib plots into Leaflet web maps'

--- a/shapely/meta.yaml
+++ b/shapely/meta.yaml
@@ -1,34 +1,34 @@
 package:
-  name: shapely
-  version: 1.5.8dev0
+    name: shapely
+    version: 1.5.8dev0
 
 source:
-  git_url: https://github.com/Toblerity/Shapely.git
-  git_tag: 2212deb2105d380345c9b558f8f4c3d3be903496
-  patches:
-    - geos_c.win.patch      # [win]
+    git_url: https://github.com/Toblerity/Shapely.git
+    git_tag: 2212deb2105d380345c9b558f8f4c3d3be903496
+    patches:
+        - geos_c.win.patch      # [win]
 
 build:
-  number: 0
+    number: 0
 
 requirements:
-  build:
-    - python
-    - geos >=3.4
-    - cython
-    - numpy
-  run:
-    - python
-    - geos
-    - numpy
+    build:
+        - python
+        - geos >=3.4
+        - cython
+        - numpy
+    run:
+        - python
+        - geos >=3.4
+        - numpy
 
 test:
-  imports:
-    - shapely
-    - shapely.speedups._speedups
-    - shapely.vectorized._vectorized
+    imports:
+        - shapely
+        - shapely.speedups._speedups
+        - shapely.vectorized._vectorized
 
 about:
-  home: https://github.com/Toblerity/Shapely
-  license: BSD
-  summary: 'Python package for manipulation and analysis of geometric objects in the Cartesian plane'
+    home: https://github.com/Toblerity/Shapely
+    license: BSD
+    summary: 'Python package for manipulation and analysis of geometric objects in the Cartesian plane'


### PR DESCRIPTION
Using a release instead of `master` for mplleaflet.