### PR TITLE
Fixed pyaxiom build for Windows and Mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
         - CONDA_PY=27  CONDA_NPY=19
 
 before_install:
-    - rm -rf nco nco-bindings pyaxiom
+    - rm -rf nco nco-bindings
     - brew update
 
 install:

--- a/pyaxiom/meta.yaml
+++ b/pyaxiom/meta.yaml
@@ -7,7 +7,7 @@ source:
     git_tag: 0.0.9
 
 build:
-    number: 1
+    number: 0
     entry_points:
         - binner=pyaxiom.netcdf.grids.binner:run
 
@@ -23,7 +23,7 @@ requirements:
         - netcdf4
         - pandas
         - pyncml
-        - nco-bindings  # [not win]
+        - nco-bindings  # [linux]
 
 test:
     imports:


### PR DESCRIPTION
@kwilcox This complements PR #229.

Just some notes on conda packaging:

In conda we reset the build number every new version.  And we bump the build number when changing the package in the same version.  Suppose we get `nco` going for Mac we would create pyaxiom-0.0.9-**1**.

Also, the conda syntax to apply (or do not apply) specific changes to a certain platform are listed here:
http://conda.pydata.org/docs/build.html#preprocessing-selectors

Thanks for the PR!