### PR TITLE
Use 32 or 64 flags.

### DIFF
--- a/geos/build.sh
+++ b/geos/build.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
 
 
-# Problems with cartopy if the -64 flag is not defined. See https://taskman.eionet.europa.eu/issues/14817.
-CFLAGS="-m64" CPPFLAGS="-m64" CXXFLAGS="-m64" LDFLAGS="-m64" FFLAGS="-m64" ./configure --prefix=$PREFIX --without-jni
+# Problems with cartopy if the -m{32,64} flag is not defined.
+# See https://taskman.eionet.europa.eu/issues/14817.
+
+MACHINE_TYPE=`uname -m`
+if [ ${MACHINE_TYPE} == 'x86_64' ]; then
+  ARCH="-m64"
+else
+  ARCH="-m32"
+fi
+
+CFLAGS=${ARCH} CPPFLAGS=${ARCH} CXXFLAGS=${ARCH} LDFLAGS=${ARCH} FFLAGS=${ARCH} \
+    ./configure --prefix=$PREFIX --without-jni
+
 make
 make install


### PR DESCRIPTION
Just to make 32 and 64 builds a little bit easier.  I am not bumping the build number on purpose.  The 64 `geos` would not change and the 32 is already in the channel, which uses this PR and the docker image.