### PR TITLE
Update utilities

### DIFF
--- a/utilities/meta.yaml
+++ b/utilities/meta.yaml
@@ -1,13 +1,13 @@
 package:
     name: utilities
-    version: "0.2.2"
+    version: "0.2.3"
 
 source:
     git_url: https://github.com/pyoceans/utilities.git
-    git_tag: v0.2.2
+    git_tag: v0.2.3
 
 build:
-    number: 2
+    number: 0
 
 requirements:
     build:
@@ -22,7 +22,7 @@ requirements:
         - folium
         - ipython-notebook
         - oceans
-        - pyugrid  # [not win]
+        - pyugrid
         - owslib
         - requests
 


### PR DESCRIPTION
Version 0.2.3

* `is_model` now assumes that all "GRID" features that have the word AVHRR are
  satellite data and not numerical models.