### PR TITLE
iris 1.8.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ platform:
     - x64
 
 install:
+    - cmd: rmdir C:\cygwin /s /q
     - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
     - cmd: set PATH=%PATH%;%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts
     - cmd: set PYTHONUNBUFFERED=1

--- a/bootstrap-obvious-ci-and-miniconda.py
+++ b/bootstrap-obvious-ci-and-miniconda.py
@@ -23,7 +23,7 @@ MINICONDA_URL_TEMPLATE = ('http://repo.continuum.io/miniconda/Miniconda{major_py
                           '{miniconda_version}-{OS}-{arch}.{ext}')
 
 
-def miniconda_url(target_system, target_arch, major_py_version, miniconda_version='3.7.0'):
+def miniconda_url(target_system, target_arch, major_py_version, miniconda_version='latest'):
     template_values = {'miniconda_version': miniconda_version}
 
     if target_arch == 'x86':
@@ -32,7 +32,7 @@ def miniconda_url(target_system, target_arch, major_py_version, miniconda_versio
         template_values['arch'] = "x86_64"
     else:
         raise ValueError('Unexpected target arch.')
-    
+
     system_to_miniconda_os = {'Linux': 'Linux',
                               'Darwin': 'MacOSX',
                               'Windows': 'Windows'}
@@ -47,11 +47,11 @@ def miniconda_url(target_system, target_arch, major_py_version, miniconda_versio
     if major_py_version not in ['2', '3']:
         raise ValueError('Unexpected major Python version {!r}.'.format(major_py_version))
     template_values['major_py_version'] = major_py_version if major_py_version == '3' else ''
-    
+
     return MINICONDA_URL_TEMPLATE.format(**template_values)
 
 
-def main(target_dir, target_arch, major_py_version, miniconda_version='3.7.0', install_obvci=True):
+def main(target_dir, target_arch, major_py_version, miniconda_version='latest', install_obvci=True):
     system = platform.system()
     URL = miniconda_url(system, target_arch, major_py_version, miniconda_version)
     basename = URL.rsplit('/', 1)[1]
@@ -65,7 +65,7 @@ def main(target_dir, target_arch, major_py_version, miniconda_version='3.7.0', i
         bin_dir = 'scripts'
     else:
         raise ValueError('Unsupported operating system.')
-    
+
     if not os.path.exists(basename):
         print('Downloading from {}'.format(URL))
         urlretrieve(URL, basename)
@@ -76,7 +76,7 @@ def main(target_dir, target_arch, major_py_version, miniconda_version='3.7.0', i
     if os.path.exists(target_dir):
         raise IOError('Installation directory already exists')
     subprocess.check_call(cmd)
-    
+
     if not os.path.isdir(target_dir):
         raise RuntimeError('Failed to install miniconda :(')
 
@@ -95,7 +95,7 @@ if __name__ == '__main__':
                         choices=['2', '3'])
     parser.add_argument('--without-obvci', help="Disable the installation of Obvious-ci.",
                         action='store_true')
-    parser.add_argument('--miniconda-version', default='3.7.0')
+    parser.add_argument('--miniconda-version', default='latest')
 
     args = parser.parse_args()
     main(args.installation_directory, args.arch, args.major_py_version,

--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -1,20 +1,20 @@
 package:
     name: iris
-    version: "1.8.0"
+    version: "1.8.1"
 
 source:
     git_url: https://github.com/SciTools/iris.git
-    git_tag: v1.8.0
+    git_tag: v1.8.1
 
 build:
-    number: 1
+    number: 0
 
 requirements:
     build:
         - python
         - scipy
         - biggus
-        - cartopy >=0.11
+        - cartopy
         - netcdf4
         - udunits2
         - pyke
@@ -24,7 +24,7 @@ requirements:
         - python
         - scipy
         - biggus
-        - cartopy >=0.11
+        - cartopy
         - matplotlib
         - netcdf4
         - ecmwf_grib >=1.12.1  # [not win]


### PR DESCRIPTION
# Bugfixes since v1.8.0:

- The PP loader now carefully handles floating point errors in date time conversions to hours.
- The handling fill values for lazy data loaded from NetCDF files is altered, such that the _FillValue set in the file is preserved through lazy operations.
- The risk that cube intersections could return incorrect results due to floating point tolerances is reduced.
- The new GRIB2 loading code is altered to enable the loading of various data representation templates; the data value unpacking is handled by the GRIB API.
- Saving cube collections to NetCDF, where multiple similar aux-factories exist within the cubes, is now carefully handled such that extra file variables are created where required in some cases.

