### PR TITLE
Adding cdo.

### DIFF
--- a/cdo/build.sh
+++ b/cdo/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+./configure --prefix=$PREFIX \
+            --disable-debug \
+            --disable-dependency-tracking \
+            --with-jasper=$PREFIX \
+            --with-grib_api=$PREFIX \
+            --with-hdf5=$PREFIX \
+            --with-netcdf=$PREFIX \
+            --with-proj=$PREFIX
+
+make
+make install

--- a/cdo/meta.yaml
+++ b/cdo/meta.yaml
@@ -1,0 +1,31 @@
+package:
+    name: cdo
+    version: 1.6.9
+
+source:
+    fn: cdo-1.6.9.tar.gz
+    url: https://code.zmaw.de/attachments/download/10198/cdo-1.6.9.tar.gz
+    md5: bf0997bf20e812f35e10188a930e24e2
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - jasper  # [not win]
+        - ecmwf_grib  # [not win]
+        - libnetcdf
+        - proj4
+    run:
+        - jasper  # [not win]
+        - ecmwf_grib  # [not win]
+        - libnetcdf
+        - proj4
+
+test:
+    commands:
+        - cdo -h
+
+about:
+    home: https://code.zmaw.de/projects/cdo
+    license: GNU General Public License v2


### PR DESCRIPTION
# Version 1.6.9 released

## New features:
- select: added parameter date, startdate, enddate
- expr: added support for operator ?:,&&,||
- option --reduce_dim: reduce dimension (Timstat, Fldstat)

## New operators:
- after: ECHAM standard post processor
- aexpr: Evaluate expressions and append results
- aexprf: Evaluate expression script and append results
- selzaxisname: Select z-axes by name
- genlevelbounds: Generate level bounds

## Fixed bugs:
- ydrunpctl: does not work in combination with ydrunmin/ydrunmax
- Ensstat: added support for different missing values
- seltimestep: abort if none of the selected timesteps are found