### PR TITLE
Adding tardis and updated utilities.

### DIFF
--- a/tardis/bld.bat
+++ b/tardis/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
+if errorlevel 1 exit 1

--- a/tardis/build.sh
+++ b/tardis/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/tardis/meta.yaml
+++ b/tardis/meta.yaml
@@ -1,0 +1,32 @@
+package:
+    name: tardis
+    version: "0.0.1"
+
+source:
+    git_url: https://github.com/pyoceans/tardis.git
+    git_tag: v0.0.1
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+        - iris
+        - pytz
+        - numpy
+        - scipy
+        - oceans
+        - pyugrid
+
+test:
+    imports:
+        - tardis
+
+about:
+    home: https://github.com/pyoceans/tardis.git
+    license: MIT License
+    summary: "TARDIS is a collection of functions for Scitools Iris"

--- a/utilities/meta.yaml
+++ b/utilities/meta.yaml
@@ -1,10 +1,10 @@
 package:
     name: utilities
-    version: "0.2.3"
+    version: "0.2.4"
 
 source:
     git_url: https://github.com/pyoceans/utilities.git
-    git_tag: v0.2.3
+    git_tag: v0.2.4
 
 build:
     number: 0
@@ -17,20 +17,21 @@ requirements:
         - python
         - iris
         - lxml
-        - pandas
-        - beautifulsoup4
-        - folium
-        - ipython-notebook
+        - tardis
         - oceans
-        - pyugrid
+        - pandas
+        - folium
         - owslib
+        - pyugrid
         - requests
+        - beautifulsoup4
+        - ipython-notebook
 
 test:
     imports:
         - utilities
 
 about:
-    home: https://github.com/ocefpaf/utilities.git
+    home: https://github.com/pyoceans/utilities.git
     license: MIT License
-    summary: "IOOS/SECOORA `utilities.py` module"
+    summary: "IOOS/SECOORA 'utilities.py' module"


### PR DESCRIPTION
I factored `iris_utils` out of `utilities` and added it as a dependency.  Nothing changes if someone install installs `utilities`, but now people can use `iris_utils` without installing unnecessary modules.