### PR TITLE
Update xray and adds some optional dependencies

### DIFF
--- a/cyordereddict/bld.bat
+++ b/cyordereddict/bld.bat
@@ -1,0 +1,1 @@
+"%PYTHON%" setup.py install

--- a/cyordereddict/build.sh
+++ b/cyordereddict/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/cyordereddict/meta.yaml
+++ b/cyordereddict/meta.yaml
@@ -1,0 +1,28 @@
+package:
+    name: cyordereddict
+    version: "0.2.2"
+
+source:
+    fn: cyordereddict-0.2.2.tar.gz
+    url: https://pypi.python.org/packages/source/c/cyordereddict/cyordereddict-0.2.2.tar.gz
+    md5: 6279eb0bf9819f0293ad5315b2d484d0
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+        - cython
+    run:
+        - python
+
+test:
+    imports:
+        - cyordereddict
+        - cyordereddict.benchmark
+
+about:
+    home: https://github.com/shoyer/cyordereddict
+    license: BSD License
+    summary: "Cython implementation of Python's collections.OrderedDict"

--- a/h5netcdf/bld.bat
+++ b/h5netcdf/bld.bat
@@ -1,0 +1,1 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt

--- a/h5netcdf/build.sh
+++ b/h5netcdf/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/h5netcdf/meta.yaml
+++ b/h5netcdf/meta.yaml
@@ -1,0 +1,29 @@
+package:
+    name: h5netcdf
+    version: "0.2.1"
+
+source:
+    fn: h5netcdf-0.2.1.tar.gz
+    url: https://pypi.python.org/packages/source/h/h5netcdf/h5netcdf-0.2.1.tar.gz
+    md5: 4b218fa2043e2aa69b12cdb98456b314
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - h5py
+    run:
+        - python
+        - h5py
+
+test:
+    imports:
+        - h5netcdf
+
+about:
+    home: https://github.com/shoyer/h5netcdf
+    license: BSD License
+    summary: 'netCDF4 via h5py'

--- a/xray/bld.bat
+++ b/xray/bld.bat
@@ -1,2 +1,1 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt

--- a/xray/build.sh
+++ b/xray/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/xray/meta.yaml
+++ b/xray/meta.yaml
@@ -1,25 +1,29 @@
 package:
     name: xray
-    version: "0.4.1"
+    version: "0.5.0"
 
 source:
-    fn: xray-0.4.1.tar.gz
-    url: https://pypi.python.org/packages/source/x/xray/xray-0.4.1.tar.gz
-    md5: 38d230c3284520f370b3821bb0b87863
+    fn: xray-0.5.0.tar.gz
+    url: https://pypi.python.org/packages/source/x/xray/xray-0.5.0.tar.gz
+    md5: 647c748f813b96361e34f40de4ce759a
 
 build:
-    number: 1
+    number: 0
 
 requirements:
     build:
         - python
         - setuptools
-        - numpy >=1.7
-        - pandas >=0.15.0
     run:
         - python
-        - numpy >=1.7
-        - pandas >=0.15.0
+        - numpy
+        - pandas
+        - netcdf4
+        - scipy
+        - bottleneck
+        - dask
+        - h5netcdf
+        - cyordereddict
 
 test:
     imports:


### PR DESCRIPTION
This PR adds:
- `cyordereddict`
- `h5netcdf`

and updates `xray` to `0.5.0` using `h5netcdf`, `cyordereddict` and `dask`.