### PR TITLE
Added siphon

### DIFF
--- a/protobuf/bld.bat
+++ b/protobuf/bld.bat
@@ -1,0 +1,1 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt

--- a/protobuf/build.sh
+++ b/protobuf/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/protobuf/meta.yaml
+++ b/protobuf/meta.yaml
@@ -1,0 +1,33 @@
+package:
+    name: protobuf
+    version: "3.0.0a3"
+
+source:
+    fn: protobuf-3.0.0a3.tar.gz
+    url: https://pypi.python.org/packages/source/p/protobuf/protobuf-3.0.0a3.tar.gz
+    md5: 6674fa7452ebf066b767075db96a7ee0
+
+build:
+    preserve_egg_dir: True
+    number: 0
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+        - setuptools
+
+test:
+    imports:
+        - google
+        - google.protobuf
+        - google.protobuf.compiler
+        - google.protobuf.internal
+        - google.protobuf.pyext
+
+about:
+    home: https://developers.google.com/protocol-buffers/
+    license: New BSD License
+    summary: 'Protocol Buffers'

--- a/siphon/bld.bat
+++ b/siphon/bld.bat
@@ -1,0 +1,1 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt

--- a/siphon/build.sh
+++ b/siphon/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/siphon/meta.yaml
+++ b/siphon/meta.yaml
@@ -1,0 +1,32 @@
+package:
+    name: siphon
+    version: "0.3.0"
+
+source:
+    fn: siphon-0.3.0.tar.gz
+    url: https://pypi.python.org/packages/source/s/siphon/siphon-0.3.0.tar.gz
+    md5: 082d1deae4ee72bc8a1a5c4eae22d8aa
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+        - numpy
+        - protobuf >=3.0.0a3
+        - requests
+        - netcdf4
+
+test:
+    imports:
+        - siphon
+        - siphon.cdmr
+
+about:
+    home: https://github.com/Unidata/siphon
+    license: MIT License
+    summary: 'A collection of Python utilities for interacting with the Unidata technology stack.'


### PR DESCRIPTION
# Siphon
- Siphon - A collection of Python utilities for retrieving data from Unidata data technologies.

An example from a mailing list:

```python
# Resolve the latest HRRR dataset
from siphon.catalog import TDSCatalog
latest_hrrr = TDSCatalog('
http://thredds-jumbo.unidata.ucar.edu/thredds/catalog/grib/HRRR/CONUS_3km/surface/latest.xml
')
hrrr_ds = list(latest_hrrr.datasets.values())[0]

# Set up access via NCSS
from siphon.ncss import NCSS
ncss = NCSS(hrrr_ds.access_urls['NetcdfSubset'])

# Create a query to ask for all times in netcdf4 format for
# the Temperature_surface variable, with a bounding box
query = ncss.query()
query.all_times().accept('netcdf4').variables('Temperature_surface')
query.lonlat_box(45, 30, -100, -90)

# Get the raw bytes and write to a file.
data = ncss.get_data_raw(query)
with open('test.nc', 'wb') as outf:
    outf.write(data)
```