### PR TITLE
Updated nco to 4.5.0

### DIFF
--- a/nco/meta.yaml
+++ b/nco/meta.yaml
@@ -1,14 +1,14 @@
 package:
     name: nco
-    version: 4.4.8
+    version: 4.5.0
 
 source:
-    fn: nco-4.4.8.tar.gz
-    url: http://nco.sourceforge.net/src/nco-4.4.8.tar.gz
-    md5: 842a118251da3875e7e2ab2cb0ec77fe
+    fn: nco-4.5.0.tar.gz
+    url: http://nco.sourceforge.net/src/nco-4.5.0.tar.gz
+    md5: cc387b92e796a778bddefab79cda0a34
 
 build:
-    number: 1
+    number: 0
 
 requirements:
     build:


### PR DESCRIPTION
  * This is the first NCO release that supports regridding datasets, currently
     limited to global datasets. These features build on infrastructure
     pioneered by Phil Jones (SCRIP), and the multi-agency Earth System
     Modeling Framework (ESMF). Other noteworthy improvements include
     capturing history from appended files, and that ncdismember uploads to
     the NERC CF-checker upon request.