### PR TITLE
Updated simplekml to 1.2.8

### DIFF
--- a/simplekml/bld.bat
+++ b/simplekml/bld.bat
@@ -1,2 +1,1 @@
 "%PYTHON%" setup.py install
-if errorlevel 1 exit 1

--- a/simplekml/meta.yaml
+++ b/simplekml/meta.yaml
@@ -1,14 +1,14 @@
 package:
     name: simplekml
-    version: "1.2.7"
+    version: "1.2.8"
 
 source:
-    fn: simplekml-1.2.7.zip
-    url: https://pypi.python.org/packages/source/s/simplekml/simplekml-1.2.7.zip
-    md5: f89cda9e7f72f27e3e3de3799672249f
+    fn: simplekml-1.2.8.zip
+    url: https://pypi.python.org/packages/source/s/simplekml/simplekml-1.2.8.zip
+    md5: 16ac3ad2639c7e50ec769baf33a0278e
 
 build:
-    number: 1
+    number: 0
 
 requirements:
     build:


### PR DESCRIPTION
# Fixes
- Fixed “global” styles repeating in each container.
- Fixed ampersand (&) not escaping correctly in urls.
- Fixed problem where files added via simplekml.Kml.addfile() were forgotten.

# Changes
- Moved the method simplekml.Kml.addfile() from being available from all classes to being available only via simplekml.Kml