### PR TITLE
Testing NCO on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-# MacOS builds.
-language: objective-c
+language: objective-c  # MacOS builds.
 
 env:
     global:
@@ -9,8 +8,12 @@ env:
         - CONDA_PY=27  CONDA_NPY=19
 
 before_install:
-    - rm -rf nco nco-bindings
     - brew update
+    # NCO.
+    - brew outdated gcc || brew upgrade gcc
+    - brew install gsl
+    # https://travis-ci.org/ioos/conda-recipes/builds/67641190
+    #- brew install antlr2
 
 install:
     # Download and run bootstrap.

--- a/nco/build.sh
+++ b/nco/build.sh
@@ -3,17 +3,25 @@
 export HAVE_NETCDF4_H=yes
 export NETCDF_ROOT=$PREFIX
 
-./configure \
-    HAVE_ANTLR=yes \
-    --prefix=$PREFIX \
-    --with-zlib=$PREFIX \
-    --disable-dependency-tracking \
-    --enable-netcdf4 \
-    --disable-static \
-    --disable-udunits \
-    --enable-udunits2 \
-    --disable-dap-opendap \
-    --enable-dap-netcdf
+if [[ $(uname) == Darwin ]]; then
+    ./configure \
+        HAVE_ANTLR=yes \
+        --prefix=$PREFIX \
+        --disable-regex \
+        --disable-shared
+else
+    ./configure \
+        HAVE_ANTLR=yes \
+        --prefix=$PREFIX \
+        --with-zlib=$PREFIX \
+        --disable-dependency-tracking \
+        --enable-netcdf4 \
+        --disable-static \
+        --disable-udunits \
+        --enable-udunits2 \
+        --disable-dap-opendap \
+        --enable-dap-netcdf
+fi
 
 make
 make install

--- a/nco/meta.yaml
+++ b/nco/meta.yaml
@@ -6,6 +6,8 @@ source:
     fn: nco-4.5.0.tar.gz
     url: http://nco.sourceforge.net/src/nco-4.5.0.tar.gz
     md5: cc387b92e796a778bddefab79cda0a34
+    patches:
+        - nodocs.patch  # [osx]
 
 build:
     number: 0
@@ -14,12 +16,11 @@ requirements:
     build:
         - curl
         - zlib
-        - libnetcdf
         - hdf5
+        - libnetcdf
         - udunits2
-        #- gsl
-        #- antlr
     run:
+        - hdf5
         - libnetcdf
         - udunits2
 
@@ -27,8 +28,8 @@ test:
     commands:
         - ncks --help
         - ncks -M http://test.opendap.org/dap/data/nc/sst.mnmean.nc.gz
-        #- ncks http://thredds-test.ucar.edu/thredds/dodsC/testdods/in.nc in.nc
-        #- ncap2 -v -s 'a=3' -s 'b=4' -s 'c=sqrt(a^2+b^2)' in.nc out.nc
+        - ncks -F --dimension time,1 http://test.opendap.org/dap/data/nc/sst.mnmean.nc.gz in.nc
+        - ncap2 -v -s 'a=3' -s 'b=4' -s 'c=sqrt(a^2+b^2)' in.nc out.nc  # [not osx]
 
 about:
     home: http://nco.sourceforge.net/

--- a/nco/nodocs.patch
+++ b/nco/nodocs.patch
@@ -1,0 +1,24 @@
+diff -Naur nco-4.5.0.orig/Makefile.am nco-4.5.0/Makefile.am
+--- nco-4.5.0.orig/Makefile.am	2015-06-11 18:15:46.000000000 -0300
++++ Makefile.am	2015-06-20 09:10:46.239764676 -0300
+@@ -1,7 +1,7 @@
+ # $Header$ -*-makefile-*-
+ 
+ #SUBDIRS = data src man doc
+-SUBDIRS = data src man @DOC_FOLDER@
++SUBDIRS = data src man
+ 
+ # Separately add desired files from nco/bld/ to distribution
+ # Autoconf does not know about the bld directory 
+diff -Naur nco-4.5.0.orig/Makefile.in nco-4.5.0/Makefile.in
+--- nco-4.5.0.orig/Makefile.in	2015-06-11 18:15:46.000000000 -0300
++++ Makefile.in	2015-06-20 09:10:39.620764347 -0300
+@@ -352,7 +352,7 @@
+ top_srcdir = @top_srcdir@
+ 
+ #SUBDIRS = data src man doc
+-SUBDIRS = data src man @DOC_FOLDER@
++SUBDIRS = data src man
+ 
+ # Separately add desired files from nco/bld/ to distribution
+ # Autoconf does not know about the bld directory 

--- a/pyaxiom/meta.yaml
+++ b/pyaxiom/meta.yaml
@@ -23,7 +23,7 @@ requirements:
         - netcdf4
         - pandas
         - pyncml
-        - nco-bindings  # [linux]
+        - nco-bindings  # [not win]
 
 test:
     imports:


### PR DESCRIPTION
Mac OS X build hints (from http://nco.sourceforge.net/build_hints.shtml):

Mac OS X users report success building NCO without patches so long as they
- (1) Install the latest version of bison
- (2) Disable shared libraries and
- (3) Disable extended regular expressions.

 This is done with

```bash
./configure --disable-regex --disable-shared
```

Building NCO with shared libraries on Mac OS X on may be possible.  To try, first re-build and re-install
the netCDF library using `CFLAGS=-fno-common`.  Apparently netCDF, unlike most codes, does not set
this automatically.  Then build NCO normally.

Mac OS X ships with a broken version of the POSIX `cut` utility which causes many NCO regression
tests to appear to fail.  In fact the NCO commands succeed, but the `cut` output fails.  The workaround is
not to heed the regression tests, or to install a working `cut`, e.g., from the GNU `coreutils` package.

PS: A homebrew and a port recipe for reference:

https://github.com/Homebrew/homebrew-science/blob/master/nco.rb

https://trac.macports.org/browser/trunk/dports/science/nco/Portfile