### PR TITLE
pycsw security issue

### DIFF
--- a/pycsw/meta.yaml
+++ b/pycsw/meta.yaml
@@ -1,12 +1,12 @@
 package:
     name: pycsw
-    version: "1.10.1"
+    version: "1.10.2"
 
 source:
     git_url: https://github.com/geopython/pycsw.git
 
 build:
-    number: 2
+    number: 0
     preserve_egg_dir: True
 
 requirements:


### PR DESCRIPTION
This version of pycsw (1.10.2) patches a important security issue that comes from libxml2 versions before 2.9.2: 
"parser.c in libxml2 before 2.9.2 does not properly prevent entity expansion even when entity substitution has been disabled, which allows context-dependent attackers to cause a denial of service (CPU consumption) via a crafted XML document containing a large number of nested entity references, a variant of the "billion laughs" attack."