### PR TITLE
Update cartopy to v0.13.0

### DIFF
--- a/cartopy/bld.bat
+++ b/cartopy/bld.bat
@@ -2,4 +2,4 @@ set LIB=%LIBRARY_LIB%;%LIB%
 set LIBPATH=%LIBRARY_LIB%;%LIBPATH%
 set INCLUDE=%LIBRARY_INC%;%INCLUDE%
 
-%PYTHON% setup.py install --single-version-externally-managed  --record record.txt
+%PYTHON% setup.py install --single-version-externally-managed --record record.txt

--- a/cartopy/build.sh
+++ b/cartopy/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-${PYTHON} -sE setup.py install --single-version-externally-managed  --record record.txt
+${PYTHON} -sE setup.py install --single-version-externally-managed --record record.txt

--- a/cartopy/meta.yaml
+++ b/cartopy/meta.yaml
@@ -1,16 +1,16 @@
 package:
     name: cartopy
-    version: 0.12.0
+    version: 0.13.0
 
 source:
     git_url: https://github.com/SciTools/cartopy.git
-    git_tag: v0.12.0
+    git_tag: v0.13.0
 
     patches:
         - cartopy.win.patch  # [win]
 
 build:
-    number: 2
+    number: 0
 
 requirements:
     build:


### PR DESCRIPTION
* Andrea Smith fixed the cartopy CRS class such that 3d transforms such as :class:`cartopy.crs.Geocentric`
  now correctly apply deg2rad and rad2deg.

* Peter Killick fixed the cartopy.crs.Mercator projection for non-zero central longitudes.

* Conversion between matplotlib :class:`matplotlib.path.Path` and
  :class:`shapely.geometry.Geometry <Shapely geometry>` using
  :func:`cartopy.mpl.patch.path_to_geos` and :func:`cartopy.mpl.patch.geos_to_path` now
  handles degenerate point paths.

* Update of tools/feature_download.py to allow mass download of feature data rather than
  on-demand downloading.