### PR TITLE
binstar -> conda-server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
     # Config conda channels.
     - conda config --set show_channel_urls True
     - conda config --add channels http://conda.binstar.org/ioos
+    - conda install --yes conda-server
     # Install Obvious-CI.
     - conda install -c http://conda.binstar.org/ioos/channel/main --yes --quiet obvious-ci
     - obvci_install_conda_build_tools.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ install:
 
     - cmd: conda install -c http://conda.binstar.org/pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels http://conda.binstar.org/ioos -f
+    - cmd: conda install --yes conda-server
     - cmd: conda info
     - cmd: obvci_install_conda_build_tools.py
 


### PR DESCRIPTION
**Do not merge this!**

Travis is failing with,

```python
File "/Users/travis/miniconda/lib/python2.7/site-packages/obvci/conda_tools/build_directory.py", line 15, in <module>
    from binstar_client.utils import get_binstar
ImportError: No module named binstar_client.utils
```

It seems that continuum moved/renamed things breaking Obvious-CI.  If this works we should fix Obvious-CI instead.