### PR TITLE
update yaml2ncml to 0.2.0

### DIFF
--- a/yaml2ncml/meta.yaml
+++ b/yaml2ncml/meta.yaml
@@ -1,10 +1,10 @@
 package:
     name: yaml2ncml
-    version: "0.1.0"
+    version: "0.2.0"
 
 source:
-    git_url: https://github.com/rsignell-usgs/yaml2ncml.git
-    git_tag: v0.1.0
+    git_url: https://github.com/usgs-cmg/yaml2ncml.git
+    git_tag: 0.2.0
 
 build:
     number: 0


### PR DESCRIPTION
upgrading to 0.2.0
- adds standard_name for time coordinate variable
- specifies project metadata correctly