### PR TITLE
Updated Obvious-CI dependencies

### DIFF
--- a/obvious-ci/meta.yaml
+++ b/obvious-ci/meta.yaml
@@ -7,7 +7,7 @@ source:
     git_tag: master
 
 build:
-    number: 2
+    number: 3
 
 requirements:
     build:
@@ -16,7 +16,7 @@ requirements:
     run:
         - python
         - setuptools
-        - binstar
+        - conda-server
         - conda
         - conda-build
 


### PR DESCRIPTION
`binstar` was renamed to `conda-server`