### PR TITLE
Unneded deps on sciwms dependencies

### DIFF
--- a/sci-wms/meta.yaml
+++ b/sci-wms/meta.yaml
@@ -22,7 +22,7 @@ requirements:
         - pytz
         - djangorestframework
         - pyugrid
-        - pysgrid == 0.1.0
+        - pysgrid
         - pyaxiom
         - django-grappelli
         - django-typed-models

--- a/sci-wms/meta.yaml
+++ b/sci-wms/meta.yaml
@@ -22,7 +22,7 @@ requirements:
         - pytz
         - djangorestframework
         - pyugrid
-        #- pysgrid  # We need a release!
+        - pysgrid == 0.1.0
         - pyaxiom
         - django-grappelli
         - django-typed-models
@@ -30,10 +30,6 @@ requirements:
         - dj-static
         - pandas
         - django-autoslug
-        # No longer in the requirements.txt! Are these still used?
-        - shapely
-        - south
-        - basemap
         # requirements-prod.txt
         - gunicorn >=0.13.4
         - setproctitle  # [not win]


### PR DESCRIPTION
This looks pretty complete, though there are a few things that aren't needed anymore.
* South
* Shapely
* Basemap

You don't need the debug-toolbar unless you're running a development machine, but that's not that critical. A user with server access could disable it at his/her discretion by modifying settings.

I've also taken this opportunity to make a pysgrid release.