### PR TITLE
Updated PyHum to 1.3.2

### DIFF
--- a/pyhum/meta.yaml
+++ b/pyhum/meta.yaml
@@ -1,12 +1,12 @@
 package:
     name: pyhum
-    version: "1.3.0"
+    version: "1.3.2"
 
 source:
-    fn: PyHum-1.3.0.tar.gz
-    url: https://pypi.python.org/packages/source/P/PyHum/PyHum-1.3.0.tar.gz
-    md5: a6192050e6a7f74da038fd3c7123c5dd
-    
+    fn: PyHum-1.3.2.tar.gz
+    url: https://pypi.python.org/packages/source/P/PyHum/PyHum-1.3.2.tar.gz
+    md5: 8eb816f99e86bdc11eede7491628ea71
+
 build:
     number: 0
 
@@ -22,10 +22,12 @@ requirements:
         - pillow
         - matplotlib
         - scikit-learn
+        - scikit-image
         - pyproj
         - joblib
         - simplekml
         - basemap
+        - pyresample
 
 test:
     imports:


### PR DESCRIPTION
- 1) map and map_texture:
implemented various ways to stop the programs crashing if low on memory, due to a grid size creating gridded data sets too large for system memory. If the system is about to crash, resolutions are doubled and functions rethrown. It will continue to do this until a gridded data set has been created.

 Gridding routines now rely on the fast pyresample module. 3 types of nearest neighbour interpolation are now supported: 1) ordinary; 2) inverse distance weighted; and 3) gaussian weighted. Use the 'mode' flag in 'map' and 'map_texture'

- 2) Point cloud outputs from the “map” module now contain georeferenced depths, ranges and headings as well as sidescan pixel intensities. This is useful in its own right, for subsequent analysis, but mostly in anticipation of a forthcoming new module called 'mosaic' which will attempt to mosaic adjacent scans together and will utilise this information

- 3) the program will now exit at the start of 'read' if the epsg code is not compatible with Basemap (which will cause problems later in the map and map_texture modules)

- 4) the 'correct' module optionally now applies a phase preserving filter to the data (via the 'dofilt' flag). Use with caution: it can be very slow for very large and very noisy data sets. By default, it is turned off.

- 5) the 'read' module now deals with data that get corrupted or lost when the user hits the 'stop recording' button before the latest ping has been written to file (this rare occasion can cause unequal numbers of pings in starboard and port, or scans). Also some changes have been made to the automatic bed picking algorithm which hopefully help that process (but it remains imperfect – always check and revert to 'manual' bedpick=2 if the bed pick is bad)

- 6) the rmshadows module has changed: in 'automatic mode' the user no longer specifies the 'number of k-means'. Instead shadow removal is achieved by examining the grey-level co-occurrence matrix of sidescan textures and removes areas of low texture. Seems like a better approach but more work/tests are necessary. Please report any feedback on this module. The 'manual' mode remains unchanged

- 7) read the module now utilizes IDX files to help speed up the process of reading data from the SON files. IDX files contain indices of start and stop pings. If these files are missing, it's not crucial – the program will revert to the old method and will take slightly longer for large files