### PR TITLE
Updated geojson to 1.2.2

### DIFF
--- a/geojson/meta.yaml
+++ b/geojson/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: geojson
-    version: "1.1.0"
+    version: "1.2.2"
 
 source:
-    fn: geojson-1.1.0.tar.gz
-    url: https://pypi.python.org/packages/source/g/geojson/geojson-1.1.0.tar.gz
-    md5: 0464ae55a25ce79a8204f71e08c1e789
+    fn: geojson-1.2.2.tar.gz
+    url: https://pypi.python.org/packages/source/g/geojson/geojson-1.2.2.tar.gz
+    md5: 8c039d712042c84352c7690aeff66d81
 
 build:
     number: 0


### PR DESCRIPTION
1.2.2 (2015-07-13)
------------------

- Fix tests by including test file into build

  - https://github.com/frewsxcv/python-geojson/issues/61

- Build universal wheels

  - https://packaging.python.org/en/latest/distributing.html#universal-wheels

1.2.1 (2015-06-25)
------------------

- Encode long types correctly with Python 2.x

  - https://github.com/frewsxcv/python-geojson/pull/57

1.2.0 (2015-06-19)
------------------

- Utility function to validate GeoJSON objects

  - https://github.com/frewsxcv/python-geojson/pull/56