### PR TITLE
Updated seawater to 3.3.3

### DIFF
--- a/seawater/bld.bat
+++ b/seawater/bld.bat
@@ -1,8 +1,1 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt

--- a/seawater/build.sh
+++ b/seawater/build.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/seawater/meta.yaml
+++ b/seawater/meta.yaml
@@ -1,20 +1,19 @@
 package:
     name: seawater
-    version: "3.3.2"
+    version: "3.3.3"
 
 source:
-    fn: seawater-3.3.2.tar.gz
-    url: https://pypi.python.org/packages/source/s/seawater/seawater-3.3.2.tar.gz
-    md5: d2aa85c5b80f5dde84e0046468609be2
+    fn: seawater-3.3.3.tar.gz
+    url: https://pypi.python.org/packages/source/s/seawater/seawater-3.3.3.tar.gz
+    md5: ae3f13a9c406bafd225fba1acd73d56c
 
 build:
-    number: 1
+    number: 0
 
 requirements:
     build:
         - python
         - setuptools
-        - numpy
     run:
         - python
         - numpy
@@ -22,7 +21,6 @@ requirements:
 test:
     imports:
         - seawater
-        - seawater.test
 
 about:
     home: http://pypi.python.org/pypi/seawater/


### PR DESCRIPTION
- Unified code base for python 2 and 3, we no longer use 2to3 to convert.