### PR TITLE
Updated simplejson to 3.8.0

### DIFF
--- a/simplejson/meta.yaml
+++ b/simplejson/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: simplejson
-    version: "3.7.3"
+    version: "3.8.0"
 
 source:
-    fn: simplejson-3.7.3.tar.gz
-    url: https://pypi.python.org/packages/source/s/simplejson/simplejson-3.7.3.tar.gz
-    md5: 117346e5ee4ed4434ffe485f8e58f5ed
+    fn: simplejson-3.8.0.tar.gz
+    url: https://pypi.python.org/packages/source/s/simplejson/simplejson-3.8.0.tar.gz
+    md5: 72f3b93a6f9808df81535f79e79565a2
 
 build:
     number: 0


### PR DESCRIPTION
* New iterable_as_array encoder option to perform lazy serialization of
  any iterable objects, without having to convert to tuple or list.