### PR TITLE
Updated ulmo to 0.7.8

### DIFF
--- a/ulmo/bld.bat
+++ b/ulmo/bld.bat
@@ -1,2 +1,1 @@
 "%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
-if errorlevel 1 exit 1

--- a/ulmo/meta.yaml
+++ b/ulmo/meta.yaml
@@ -1,28 +1,19 @@
 package:
     name: ulmo
-    version: "0.7.6"
+    version: "0.7.8"
 
 source:
-    git_url: https://github.com/ulmo-dev/ulmo.git
-    git_tag: v0.7.6
+    fn: ulmo-0.7.8.tar.gz
+    url: https://pypi.python.org/packages/source/u/ulmo/ulmo-0.7.8.tar.gz
+    md5: 77399fec522ed3db9a4a22d9e62b9513
 
 build:
-    number: 1
+    number: 0
 
 requirements:
     build:
         - python
         - setuptools
-        - appdirs
-        - beautifulsoup4
-        - isodate
-        - lxml
-        - mock
-        - numpy
-        - pandas
-        - requests
-        - suds
-        - pytables
     run:
         - python
         - appdirs


### PR DESCRIPTION
**0.7.8 (released 2015-07-02)**

- no changes, had to bump version number because of a corrupt file uploaded to pypi.

**0.7.7 (released 2015-07-02)**

- dropped python 2.6 support
- fixed bug in extracting raster file from zip file on windows
- fixes for cdec service
- fix url_params kwarg typo for nwis service