### PR TITLE
Updated Obvious-CI dependencies

### DIFF
--- a/obvious-ci/meta.yaml
+++ b/obvious-ci/meta.yaml
@@ -7,7 +7,7 @@ source:
     git_tag: master
 
 build:
-    number: 3
+    number: 4
 
 requirements:
     build:
@@ -15,10 +15,9 @@ requirements:
         - setuptools
     run:
         - python
-        - setuptools
-        - conda-server
         - conda
         - conda-build
+        - anaconda-client
 
 about:
     home: https://github.com/pelson/Obvious-CI


### PR DESCRIPTION
`binstart` was renamed to `conda-server` that was renamed to `anaconda-client`... Hopefully Continuum will stop renaming it now!