### PR TITLE
Update meta.yaml

### DIFF
--- a/flopy/meta.yaml
+++ b/flopy/meta.yaml
@@ -1,10 +1,10 @@
 package:
     name: flopy
-    version: "3.2.1"
+    version: "3.2.2"
 
 source:
     git_url: https://github.com/modflowpy/flopy.git
-    git_tag: 3.2.1
+    git_tag: 3.2.2
 
 build:
     number: 0


### PR DESCRIPTION
Update flopy version. Previous meta.yaml update attemp had code with import pandas that was not being used. Commented out for now. As a result no need for pandas in setup.py.