### PR TITLE
Leave Cygwin be...

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,6 @@ platform:
     - x64
 
 install:
-    - cmd: rmdir C:\cygwin /s /q
     - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
     - cmd: set PATH=%PATH%;%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts
     - cmd: set PYTHONUNBUFFERED=1


### PR DESCRIPTION
Cygwin git [was](https://github.com/ocefpaf/conda-recipes/commit/79ff4f8f8992deae2c5e66f04f564c6788ed7c2e) crashing before, but it turns out to be [conda's fault](https://github.com/conda/conda/issues/747) and that is fixed now!