### PR TITLE
Better metapackages

### DIFF
--- a/sci-wms/bld.bat
+++ b/sci-wms/bld.bat
@@ -1,2 +1,0 @@
-echo 1.1.0 > __conda_version__.txt
-rem  echo "/opt/anaconda1anaconda2anaconda3" > "%PREFIX%\test-has-prefix"

--- a/sci-wms/build.sh
+++ b/sci-wms/build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-echo 1.1.0 > __conda_version__.txt
-echo 0 > __conda_buildstr__.txt
-# echo 10 > __conda_buildnum__.txt
-
-# echo "/opt/anaconda1anaconda2anaconda3" > $PREFIX/test-has-prefix


### PR DESCRIPTION
According to the conda mailing list we do not need `build.sh` and `bld.bat` for metapackages.