### PR TITLE
Updated tardis to 0.1.1

### DIFF
--- a/tardis/meta.yaml
+++ b/tardis/meta.yaml
@@ -1,10 +1,10 @@
 package:
     name: tardis
-    version: "0.1.0"
+    version: "0.1.1"
 
 source:
     git_url: https://github.com/pyoceans/tardis.git
-    git_tag: v0.1.0
+    git_tag: v0.1.1
 
 build:
     number: 0


### PR DESCRIPTION
Version 0.1.1

* Fixed a bug in `save_timeseries ` to cast all netCDF4 variables in the
  expected dtype.