### PR TITLE
Using PyPI release instead of git hash

### DIFF
--- a/folium/meta.yaml
+++ b/folium/meta.yaml
@@ -3,11 +3,12 @@ package:
     version: "0.1.5"
 
 source:
-    git_url: https://github.com/python-visualization/folium.git
-    git_branch: 65c6a3db9f84fee66b834bd8cbfe92ca0ef9f9dd
+    fn: folium-0.1.5.tar.gz
+    url: https://pypi.python.org/packages/source/f/folium/folium-0.1.5.tar.gz
+    md5: 64bfb417ce53638a3f57245bcaf38215
 
 build:
-    number: 0
+    number: 1
 
 requirements:
     build:


### PR DESCRIPTION
Should be the same version...