### PR TITLE
Pin Django version

### DIFF
--- a/django-debug-toolbar/meta.yaml
+++ b/django-debug-toolbar/meta.yaml
@@ -8,7 +8,7 @@ source:
     md5: af197364e92b99733020890ede5fe5af
 
 build:
-    number: 0
+    number: 1
 
 requirements:
     build:
@@ -16,7 +16,7 @@ requirements:
         - setuptools
     run:
         - python
-        - django >=1.4.2
+        - django >=1.7,<1.8
         - sqlparse
 
 test:

--- a/django-extensions/meta.yaml
+++ b/django-extensions/meta.yaml
@@ -8,7 +8,7 @@ source:
     md5: 2c0b90a474ddb75764573f97a1481b82
 
 build:
-    number: 0
+    number: 1
 
 requirements:
     build:
@@ -17,7 +17,7 @@ requirements:
     run:
         - python
         - six >=1.2
-        - django
+        - django >=1.7,<1.8
 
 test:
     imports:


### PR DESCRIPTION
@kwilcox this should help you with https://github.com/sci-wms/sci-wms/pull/68

In theory we do not need to do this.  Conda should use the proper version if everything were in one `requirements.txt` file and only one line with `django >=1.7,<1.8` there should do the trick.  Since we only have these packages for `sci-wms` I do not see the harm in enforcing the version here too.  Let me know if there are more roadblocks like this.