### PR TITLE
Update xray to 0.6.0

### DIFF
--- a/xray/meta.yaml
+++ b/xray/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: xray
-    version: "0.5.2"
+    version: "0.6.0"
 
 source:
-    fn: xray-0.5.2.tar.gz
-    url: https://pypi.python.org/packages/source/x/xray/xray-0.5.2.tar.gz
-    md5: a42a1aca4de9e0485fdebce63ce2248a
+    fn: xray-0.6.0.tar.gz
+    url: https://pypi.python.org/packages/source/x/xray/xray-0.6.0.tar.gz
+    md5: f6331054e509b92e7f87b0db1cb84954
 
 build:
     number: 0


### PR DESCRIPTION
v0.6.0 (21 August 2015)
-----------------------

This release includes numerous bug fixes and enhancements. Highlights
include the introduction of a plotting module and the new Dataset and DataArray
methods :py:meth:`~xray.Dataset.isel_points`, :py:meth:`~xray.Dataset.sel_points`,
:py:meth:`~xray.Dataset.where` and :py:meth:`~xray.Dataset.diff`. There are no
breaking changes from v0.5.2.