### PR TITLE
Remove octant for Win64

### DIFF
--- a/octant/bld.bat
+++ b/octant/bld.bat
@@ -1,3 +1,0 @@
-"%PYTHON%" setup.py build --compiler=mingw32
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1


### PR DESCRIPTION
Sadly I could not get `mingwpy` to work on AppVeyor Win64.