### PR TITLE
libmo_unpack patch

### DIFF
--- a/libmo_unpack/build.sh
+++ b/libmo_unpack/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 mkdir m4
+
+# Patch the configure.ac as per https://lists.ubuntu.com/archives/fwts-devel/2013-June/003391.html
+sed -i".ac" -e 's/AM_PROG_AR/m4_ifdef([AM_PROG_AR], [AM_PROG_AR])/g' configure.ac
 autoreconf --install
 
 CFLAGS="-O3 -mfpmath=sse -msse"

--- a/libmo_unpack/meta.yaml
+++ b/libmo_unpack/meta.yaml
@@ -7,7 +7,7 @@ source:
     git_rev: v3.0
 
 build:
-    number: 0
+    number: 1
 
 about:
     home: https://github.com/SciTools/libmo_unpack


### PR DESCRIPTION
Easier than installing a newer autoreconf on Centos.
(See https://github.com/SciTools/conda-recipes-scitools/pull/101/files.)