### PR TITLE
Bake python string

### DIFF
--- a/cf_units/meta.yaml
+++ b/cf_units/meta.yaml
@@ -7,13 +7,13 @@ source:
     git_tag: v0.1.0
 
 build:
-    number: 1
+    number: 2
 
 requirements:
     build:
-        - python <3
+        - python >=2.7,<3
     run:
-        - python <3
+        - python
         - udunits2
         - netcdf4
         - numpy

--- a/compliance-checker/meta.yaml
+++ b/compliance-checker/meta.yaml
@@ -7,13 +7,13 @@ source:
     git_tag: 1.1.1
 
 build:
-    number: 1
+    number: 2
     entry_points:
         - compliance-checker = cchecker:main
 
 requirements:
     build:
-        - python <3
+        - python >=2.7,<3
         - setuptools
         - owslib
         - wicken
@@ -22,7 +22,7 @@ requirements:
         - requests
         - python-dateutil
     run:
-        - python <3
+        - python
         - owslib
         - wicken
         - lxml

--- a/iris/meta.yaml
+++ b/iris/meta.yaml
@@ -7,11 +7,11 @@ source:
     git_tag: v1.8.1
 
 build:
-    number: 1
+    number: 2
 
 requirements:
     build:
-        - python <3
+        - python >=2.7,<3
         - scipy
         - biggus
         - cartopy
@@ -21,7 +21,7 @@ requirements:
         - setuptools
         - libmo_unpack  # [not win]
     run:
-        - python <3
+        - python
         - scipy
         - biggus
         - cartopy

--- a/octant/meta.yaml
+++ b/octant/meta.yaml
@@ -7,16 +7,16 @@ source:
     git_tag: master
 
 build:
-    number: 2
+    number: 3
 
 requirements:
     build:
-        - python <3
+        - python >=2.7,<3
         - numpy
         - setuptools
         - mingwpy  # [win]
     run:
-        - python <3
+        - python
         - numpy
         - netcdf4
         - matplotlib

--- a/optcomplete/meta.yaml
+++ b/optcomplete/meta.yaml
@@ -8,13 +8,13 @@ source:
     md5: 6392cd0a7154b3394004d5ad9d913d59
 
 build:
-    number: 2
+    number: 3
 
 requirements:
     build:
-        - python <3
+        - python >=2.7,<3
     run:
-        - python <3
+        - python
 
 test:
     imports:

--- a/paegan-transport/meta.yaml
+++ b/paegan-transport/meta.yaml
@@ -7,14 +7,14 @@ source:
   git_tag: db8f957f5f379def417f93c1941d3f20dbbf16bb
 
 build:
-    number: 1
+    number: 2
 
 requirements:
     build:
-        - python <3
+        - python >=2.7,<3
         - setuptools
     run:
-        - python <3
+        - python
         - paegan
         - fiona
         - requests

--- a/petulant-bear/meta.yaml
+++ b/petulant-bear/meta.yaml
@@ -8,14 +8,14 @@ source:
     md5: 71788a47d6a9c7b0081ab81348c4f4a9
 
 build:
-    number: 1
+    number: 2
 
 requirements:
     build:
-        - python <3
+        - python >=2.7,<3
         - setuptools
     run:
-        - python <3
+        - python
         - netcdf4
         - numpy
         - lxml

--- a/pycsw/meta.yaml
+++ b/pycsw/meta.yaml
@@ -6,12 +6,12 @@ source:
     git_url: https://github.com/geopython/pycsw.git
     git_tag: 1.10.2
 build:
-    number: 1
+    number: 2
     preserve_egg_dir: True
 
 requirements:
     build:
-        - python <3
+        - python >=2.7,<3
         - setuptools
         - sqlalchemy
         - geolinks
@@ -20,7 +20,7 @@ requirements:
         - pyproj
         - shapely
     run:
-        - python <3
+        - python
         - sqlalchemy
         - geolinks
         - lxml

--- a/pygdp/meta.yaml
+++ b/pygdp/meta.yaml
@@ -7,15 +7,15 @@ source:
     git_tag: v1.3.2
 
 build:
-    number: 2
+    number: 3
 
 requirements:
     build:
-        - python <3
+        - python >=2.7,<3
         - setuptools
         - owslib
     run:
-        - python <3
+        - python
         - owslib
         - python-dateutil
         - lxml

--- a/pyhum/meta.yaml
+++ b/pyhum/meta.yaml
@@ -8,15 +8,15 @@ source:
     md5: 8eb816f99e86bdc11eede7491628ea71
 
 build:
-    number: 1
+    number: 2
 
 requirements:
     build:
-        - python <3
+        - python >=2.7,<3
         - cython
         - numpy
     run:
-        - python <3
+        - python
         - numpy
         - scipy
         - pillow

--- a/suds/meta.yaml
+++ b/suds/meta.yaml
@@ -8,14 +8,14 @@ source:
     md5: b7502de662341ed7275b673e6bd73191
 
 build:
-    number: 2
+    number: 3
 
 requirements:
     build:
-        - python <3
+        - python >=2.7,<3
         - setuptools
     run:
-        - python <3
+        - python
 
 test:
     imports:

--- a/tardis/meta.yaml
+++ b/tardis/meta.yaml
@@ -7,14 +7,14 @@ source:
     git_tag: v0.1.1
 
 build:
-    number: 1
+    number: 2
 
 requirements:
     build:
-        - python <3
+        - python >=2.7,<3
         - setuptools
     run:
-        - python <3
+        - python
         - iris
         - pytz
         - numpy

--- a/ulmo/meta.yaml
+++ b/ulmo/meta.yaml
@@ -8,14 +8,14 @@ source:
     md5: 77399fec522ed3db9a4a22d9e62b9513
 
 build:
-    number: 1
+    number: 2
 
 requirements:
     build:
-        - python <3
+        - python >=2.7,<3
         - setuptools
     run:
-        - python <3
+        - python
         - appdirs
         - beautifulsoup4
         - isodate

--- a/unit_conversion/meta.yaml
+++ b/unit_conversion/meta.yaml
@@ -7,14 +7,14 @@ source:
     git_tag: v2.2
 
 build:
-    number: 1
+    number: 2
 
 requirements:
     build:
-        - python <3
+        - python >=2.7,<3
         - setuptools
     run:
-        - python <3
+        - python
 
 test:
     imports:

--- a/utilities/meta.yaml
+++ b/utilities/meta.yaml
@@ -7,14 +7,14 @@ source:
     git_tag: v0.3.0
 
 build:
-    number: 1
+    number: 2
 
 requirements:
     build:
-        - python <3
+        - python >=2.7,<3
         - setuptools
     run:
-        - python <3
+        - python
         - iris  # [not py3k]
         - lxml
         - tardis  # [not py3k]

--- a/wicken/meta.yaml
+++ b/wicken/meta.yaml
@@ -8,17 +8,17 @@ source:
     md5: b522b3e713a8dd90d11c2dbc1cdd44c9
 
 build:
-    number: 2
+    number: 3
 
 requirements:
     build:
-        - python <3
+        - python >=2.7,<3
         - setuptools
         - nose >=1.2.0
         - lxml >=3.2.1
         - petulant-bear >=0.1.2
     run:
-        - python <3
+        - python
         - nose >=1.2.0
         - lxml >=3.2.1
         - petulant-bear >=0.1.2


### PR DESCRIPTION
Using `<3` in both the `build` and `run` produced packages without the `py` version string!  In this PR we test specifying a more restrictive condition on the `build` only.

http://anaconda.org/IOOS/iris/1.8.1/download/linux-64/iris-1.8.1-np_1.tar.bz2