### PR TITLE
Added extra reqs

### DIFF
--- a/owslib/meta.yaml
+++ b/owslib/meta.yaml
@@ -7,7 +7,7 @@ source:
     git_tag: 0.9.0
 
 build:
-    number: 0
+    number: 1
 
 requirements:
     build:
@@ -18,6 +18,8 @@ requirements:
         - python-dateutil
         - pytz
         - requests
+        - lxml
+        - pyproj
 
 test:
     imports:


### PR DESCRIPTION
Updates the requirements  for OWSLib with `lxml` and `pyproj`.

@rsignell-usgs ths should solve https://github.com/USGS-CIDA/pyGDP/issues/120#issuecomment-137390878