### PR TITLE
Updated geolinks to 0.2.0

### DIFF
--- a/geolinks/meta.yaml
+++ b/geolinks/meta.yaml
@@ -1,14 +1,14 @@
 package:
     name: geolinks
-    version: "0.1.0"
+    version: "0.2.0"
 
 source:
-    fn: geolinks-0.1.0.tar.gz
-    url: https://pypi.python.org/packages/source/g/geolinks/geolinks-0.1.0.tar.gz
-    md5: c868d699319e8dee7a10f6745441107c
+    fn: geolinks-0.2.0.tar.gz
+    url: https://pypi.python.org/packages/source/g/geolinks/geolinks-0.2.0.tar.gz
+    md5: d3deb3ae7afd2670b8deb9bf00c7a13c
 
 build:
-    number: 1
+    number: 0
 
 requirements:
     build:


### PR DESCRIPTION
Python 3K support, slight API changes

```python
>>> from geolinks import sniff_link
>>> sniff_link('http://host/wms?service=WMS')
'OGC:WMS'
>>> sniff_link('http://host/wms?service=WPS')
'OGC:WPS'
>>> sniff_link('http://host/wms?service=CSW')
'OGC:CSW'
>>> sniff_link('http://host/data/roads.kmz')
'OGC:KML'
>>> sniff_link('http://host/data/roads.kml')
'OGC:KML'
```