### PR TITLE
Update nco to 4.5.2

### DIFF
--- a/nco/build.sh
+++ b/nco/build.sh
@@ -4,6 +4,7 @@ export HAVE_NETCDF4_H=yes
 export NETCDF_ROOT=$PREFIX
 
 if [[ $(uname) == Darwin ]]; then
+export LDFLAGS="-headerpad_max_install_names"
     ./configure \
         HAVE_ANTLR=yes \
         --prefix=$PREFIX \

--- a/nco/meta.yaml
+++ b/nco/meta.yaml
@@ -1,11 +1,10 @@
 package:
     name: nco
-    version: 4.5.1
+    version: "4.5.2"
 
 source:
-    fn: nco-4.5.1.tar.gz
-    url: http://nco.sourceforge.net/src/nco-4.5.1.tar.gz
-    md5: b830dd0a825335731a7c9ecd45c0a00f
+    git_url: https://github.com/nco/nco.git
+    git_tag: 4.5.2
     patches:
         - nodocs.patch  # [osx]
 


### PR DESCRIPTION
- NEW FEATURES

- A. All operators can now add user-specified global attributes to
    output files using the --glb switch. The switch takes mandatory
    arguments --glb att_nm=att_val where att_nm is the desired name of
    the global attriute to add, and att_val is its value.
    Currently only text attributes are supported (recorded as type
    NC_CHAR, and regular expressions are not allowed (unlike ncatted).
    Multiple invocations simplify the annotation of output file at
    creation (or modification) time, and incur no performance penalty.
    Should users emit a loud hue and cry, we will consider ading the
    the functionality of ncatted to the front-end of all operators,
    i.e., accepting valid arguments to modify attributes of any type
    and to apply regular expressions.
    ncra --glb machine=${HOSTNAME} --glb created_by=${USER} in*.nc out.nc
    http://nco.sf.net/nco.html#glb

- B. Grid generation: ncks generates SCRIP-format gridfiles for
    select grid types, in cluding uniform/equi-angular, cap/FV, and
    Gaussian. Options pertinent to the grid geometry and metadata are
    passed to NCO via key-value pairs prefixed by "--rgr". Pass at
    least six key-value pair arguments to create a fully explicitly
    specified, well-annotated grid. The six arguments, and their
    corresponding keys in parentheses, are: grid title (grd_ttl),
    filename to write the grid to (grid), number of latitudes
    (lat_nbr), number of longitudes (lon_nbr), latitude grid type
    (lat_typ), and longitude grid type (lon_typ). Four other arguments
    (the NSEW bounding box) are necessary to construct regular regional
    (non-global) grids.
    ncks -grid=FV129x256.nc \
    --rgr lat_nbr=129 --rgr lon_nbr=256 --rgr lat_typ=cap
    --rgr lon_typ=grn_ctr ~zender/nco/data/in.nc ~/foo.nc
    ncks -grid=T42.nc \
    --rgr lat_nbr=64 --rgr lon_nbr=128 --rgr lat_typ=gss
    --rgr lon_typ=grn_ctr ~zender/nco/data/in.nc ~/foo.nc
    http://nco.sf.net/nco.html#grid

- C. Regrid regional datasets with ESMF, SCRIP, and TempestRemap
    mapfiles. Please give it a try and send us feedback!
    Regrid global file to regional domain
    ncks --map map_conusx4v1_to_fv0.1x0.1_US_bilin.nc in.nc out.nc
    http://nco.sf.net/nco.html#regrid

- D. Multi-file operators support a new extension to the -n option
    that understands calendar month counting. It is now possibly to
    automatically generate series of filenames whose right-most two
    digits increment from a specified minimum (e.g., 03) by a specified
    amount (e.g., 1) until a specified maximum (e.g., 05) is reached
    and then the leftmost digits (i.e., the year) increments by one,
    and the whole process is reapeated until the total specified number
    of filenames is generated.
    ncrcat -n 3,6,1,12,1,yyyymm 198512.nc 198512_198602.nc
    http://nco.sf.net/nco.html#input

- BUG FIXES:

- A. The ncra --wgt option, introduced in 4.4.9, works fine except,
    it turns out, for variables with missing values. The normalization
    for these values was incorrect and produced errors whose size was
    roughly inversely proportional to the size of the weights.
    The solution is to upgrade to 4.5.2. Thanks to Jeff Painter for
    reporting this problem.