### PR TITLE
Update biggus to 0.12.0

### DIFF
--- a/biggus/bld.bat
+++ b/biggus/bld.bat
@@ -1,2 +1,2 @@
-%PYTHON% setup.py install
+%PYTHON% setup.py install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1

--- a/biggus/build.sh
+++ b/biggus/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/biggus/meta.yaml
+++ b/biggus/meta.yaml
@@ -1,10 +1,10 @@
 package:
     name: biggus
-    version: "0.11.0"
+    version: "0.12.0"
 
 source:
     git_url: https://github.com/SciTools/biggus
-    git_tag: v0.11.0
+    git_tag: v0.12.0
 
 build:
     number: 0


### PR DESCRIPTION
- A fix for the `__getitem__` for `LinearMosaic` that corrects array slicing output (147).
- Biggus' `__div__` method properly accounts for the dtype of arguments passed to it (149).
- Added support for Python 3.5 (150).