### PR TITLE
Enable Python3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,4 @@ install:
     - obvci_install_conda_build_tools.py
 
 script:
-    - obvci_conda_build_dir.py ./ ioos --channel main --build-condition "python >=2.7,<3|==3.4"
+    - obvci_conda_build_dir.py ./ ioos --channel main --build-condition "python >=2.7,<3|>=3.4"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ platform:
     - x64
 
 install:
-    - cmd: python -c "from urllib2 import urlopen; open('bootstrap-obvious-ci-and-miniconda.py', 'w').write(urlopen('https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py').read())"
+    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
     - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% 2 --without-obvci
     - cmd: set CONDA_PY=%CONDA_PY%
     - cmd: set PATH=%PATH%;%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts

--- a/github3.py/meta.yaml
+++ b/github3.py/meta.yaml
@@ -32,7 +32,7 @@ test:
     requires:
         - betamax >=0.2.0
         - betamax-matchers >=0.1.0
-        - mock ==1.0.1
+        - mock ==1.0.1  # [not py35]
         - pytest
 
 about:

--- a/pynco/meta.yaml
+++ b/pynco/meta.yaml
@@ -15,7 +15,7 @@ requirements:
         - setuptools
     run:
         - python
-        - dateutil
+        - python-dateutil
         - h5py
         - netcdf4
         - numpy

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -36,6 +36,6 @@ conda info
 
 export LANG=en_US.UTF-8
 
-obvci_conda_build_dir.py /conda-recipes $UPLOAD_OWNER --build-condition "python >=2.7,<3|==3.4"
+obvci_conda_build_dir.py /conda-recipes $UPLOAD_OWNER --build-condition "python >=2.7,<3|>=3.4"
 
 EOF

--- a/xray/meta.yaml
+++ b/xray/meta.yaml
@@ -20,7 +20,7 @@ requirements:
         - pandas
         - netcdf4
         - scipy
-        - bottleneck
+        - bottleneck  # [not py35]
         - dask
         - h5netcdf
         - cyordereddict


### PR DESCRIPTION
~~**DO NOT MERGE THIS !!!**~~

- [X] Removed `django-debug-toolbar` dependency on `django <1.8`.
- [X] Default channel does not package `dateutil` for py35.  Ours seems to be working so I changed `pynco` do use that instead.
- [X] Removed `mock` in `github3.py`. In py35 `mock` is part of the standard library.
- [X] Default channel does not package `bottleneck` for py35.  Since it is an optional `xray` dependency I just removed it from the build.