### PR TITLE
Fixed nn source and license

### DIFF
--- a/nn/build.sh
+++ b/nn/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd nn
+
 ./configure --prefix=$PREFIX
 make
 make tests

--- a/nn/meta.yaml
+++ b/nn/meta.yaml
@@ -1,17 +1,16 @@
 package:
     name: nn
-    version: 1.85
+    version: "1.85.1"
 
 source:
-    #git_url: https://github.com/phobson/nn.git
-    #git_tag: v1.85
-    git_url: https://github.com/ocefpaf/nn.git
-    git_tag: points_generate2
+    git_url: https://github.com/sakov/nn-c.git
+    #git_tag: v1.85.1
+    git_tag: master
 
 build:
-    number: 3
+    number: 0
 
 about:
-    home: https://code.google.com/p/nn-c
-    license: MIT License
-    summary: "Pavel Sakov's natural neighbors library"
+    home: https://github.com/sakov/nn-c.git
+    license: Simplified BSD License and triangle.[c,h] license, which is non-free for commercial use
+    summary: "Natural Neighbours interpolation"


### PR DESCRIPTION
**DO NOT MERGE THIS:**  I am waiting for an official release.  If that does not happen than we can consider merging it.

This PR fixes the license and source for the code.

NB: The `triangle.[c,h]` license is non-free for commercial use! :ghost: 