### PR TITLE
Updated gridutils to 1.0

### DIFF
--- a/gridutils/build.sh
+++ b/gridutils/build.sh
@@ -4,6 +4,8 @@ export CFLAGS="-I$PREFIX/include $CFLAGS"
 export LDFLAGS="-L$PREFIX/lib $LDFLAGS"
 export CPPFLAGS="-I/$PREFIX/include $CPPFLAGS"
 
+cd gridutils
+
 ./configure --prefix=$PREFIX
 
 make

--- a/gridutils/meta.yaml
+++ b/gridutils/meta.yaml
@@ -1,13 +1,13 @@
 package:
     name: gridutils
-    version: "0.51"
+    version: "v1.0"
 
 source:
-    git_url: https://github.com/phobson/gridutils.git
-    git_tag: 0.51
+    git_url: https://github.com/sakov/gridutils-c.git
+    git_tag: v1.0
 
 build:
-    number: 3
+    number: 0
 
 requirements:
     build:
@@ -18,6 +18,6 @@ requirements:
         - csa
 
 about:
-    home: https://code.google.com/p/gridutils-c
-    license: MIT License
-    summary: "Pavel Sakov's curvilinear orthogonal grid utilities"
+    home: https://github.com/sakov/gridutils-c.git
+    license: Simplified BSD
+    summary: "C library functions and command line utilities for working with curvilinear grids."


### PR DESCRIPTION
This PR fixes code source, code license, updated version, and add some extra metadata.

Changelog
--------------

- v. 0.54, 5 May 2015
  - Introduced gu_setquitfn() to set the quit function externally;  the previous (internal) version is used as default.
- v. 0.53, 3 Mar 2015
  - Corrected the header guard in gridnodes.h
- v. 0.52, 4 Jul 2013
  - Added a new constructor gridnodes_create2()
  - Using a saved errno in strerror() now