### PR TITLE
Updated Shapely to 1.5.12

### DIFF
--- a/shapely/geos_c.win.patch
+++ b/shapely/geos_c.win.patch
@@ -1,6 +1,6 @@
---- shapely/libgeos.py	2015-08-23 11:23:35.000000000 -0300
-+++ shapely/libgeos.py	2015-08-29 18:11:53.458018649 -0300
-@@ -183,9 +183,10 @@
+--- shapely/libgeos.py	2015-08-27 10:50:33.000000000 -0300
++++ shapely/libgeos.py	2015-09-22 09:04:40.507509936 -0300
+@@ -182,9 +182,10 @@
                  os.path.join(os.path.dirname(__file__), "DLLs"))
              wininst_dlls = os.path.abspath(os.__file__ + "../../../DLLs")
              original_path = os.environ['PATH']

--- a/shapely/meta.yaml
+++ b/shapely/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: shapely
-    version: 1.5.11
+    version: 1.5.12
 
 source:
-    fn: Shapely-1.5.11.tar.gz
-    url: https://pypi.python.org/packages/source/S/Shapely/Shapely-1.5.11.tar.gz
-    md5: 37530a4f9418917c9afd38fcd15bc891
+    fn: Shapely-1.5.12.tar.gz
+    url: https://pypi.python.org/packages/source/S/Shapely/Shapely-1.5.12.tar.gz
+    md5: 928d1fda2db064d82288092ea32ef3a9
     patches:
         - geos_c.win.patch  # [win]
         - osx-geos.patch # [osx]
@@ -18,6 +18,7 @@ requirements:
         - geos >=3.4
         - cython
         - numpy
+        - msinttypes  # [win]
     run:
         - python
         - geos >=3.4


### PR DESCRIPTION
Changes
=======

1.5.12 (2015-08-27)
-------------------
- Remove configuration of root logger from libgeos.py (312).
- Skip test_fallbacks on Windows (308).
- Call setlocale(locale.LC_ALL, "") instead of resetlocale() on Windows when
  tearing down the locale test (308).
- Fix for Sphinx warnings (309).
- Addition of .cache, .idea, .pyd, .pdb to .gitignore (310).