### PR TITLE
Updated pyhum to 1.3.3

### DIFF
--- a/pyhum/meta.yaml
+++ b/pyhum/meta.yaml
@@ -1,14 +1,14 @@
 package:
     name: pyhum
-    version: "1.3.2"
+    version: "1.3.3"
 
 source:
-    fn: PyHum-1.3.2.tar.gz
-    url: https://pypi.python.org/packages/source/P/PyHum/PyHum-1.3.2.tar.gz
-    md5: 8eb816f99e86bdc11eede7491628ea71
+    fn: PyHum-1.3.3.tar.gz
+    url: https://pypi.python.org/packages/source/P/PyHum/PyHum-1.3.3.tar.gz
+    md5: 2f82d04eef58a6fbe8d2ec1a4be0fcc9
 
 build:
-    number: 2
+    number: 0
 
 requirements:
     build:


### PR DESCRIPTION
- 1) Fixed small bug in e1e2 module that was using smoothed easting/northing coordinates rather than actual coordinates

- 2) in map module, if mode =3 (nearest neighbour with gaussina smoothing), the sigma on the gaussian function has been changed from 1 to 0.1, due to sigma = 1 oversmoothing. Will implement this as a user input variable in a future release

- 3) the 'correct' module now has a new flag, 'correct_withwater'. If correct_withwater=0 [default], the usual/old behaviour is observed. If correct_withwater=1, radiometric corrections are carried out on scans without water column removed, and a new set of files (*__data_star_lw.dat and *_data_port_lw.dat) are produced