### PR TITLE
Added pelican and its dependencies

### DIFF
--- a/blinker/bld.bat
+++ b/blinker/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/blinker/build.sh
+++ b/blinker/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install install --single-version-externally-managed --record record.txt

--- a/blinker/meta.yaml
+++ b/blinker/meta.yaml
@@ -1,0 +1,26 @@
+package:
+    name: blinker
+    version: "1.4"
+
+source:
+    fn: blinker-1.4.tar.gz
+    url: https://pypi.python.org/packages/source/b/blinker/blinker-1.4.tar.gz
+    md5: 8b3722381f83c2813c52de3016b68d33
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+
+test:
+    imports:
+        - blinker
+about:
+    home: http://pythonhosted.org/blinker/
+    license: MIT License
+    summary: 'Fast, simple object-to-object and broadcast signaling'

--- a/feedgenerator/bld.bat
+++ b/feedgenerator/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/feedgenerator/build.sh
+++ b/feedgenerator/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/feedgenerator/meta.yaml
+++ b/feedgenerator/meta.yaml
@@ -1,0 +1,31 @@
+package:
+    name: feedgenerator
+    version: "1.7"
+
+source:
+    fn: feedgenerator-1.7.tar.gz
+    url: https://pypi.python.org/packages/source/f/feedgenerator/feedgenerator-1.7.tar.gz
+    md5: 92978492871342ad64e8ae0ccfcf200c
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+        - pytz >=0a
+        - six
+
+test:
+    imports:
+        - feedgenerator
+        - feedgenerator.django
+        - feedgenerator.django.utils
+
+about:
+    home: https://github.com/dmdm/feedgenerator-py3k.git
+    license: BSD License
+    summary: 'Standalone version of django.utils.feedgenerator, compatible with Py3k'

--- a/ghp-import/bld.bat
+++ b/ghp-import/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/ghp-import/build.sh
+++ b/ghp-import/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/ghp-import/meta.yaml
+++ b/ghp-import/meta.yaml
@@ -1,0 +1,23 @@
+package:
+    name: ghp-import
+    version: "0.4.1"
+
+source:
+    fn: ghp-import-0.4.1.tar.gz
+    url: https://pypi.python.org/packages/source/g/ghp-import/ghp-import-0.4.1.tar.gz
+    md5: 99e018372990c03ab355aa62c34965c5
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+
+about:
+    home: http://github.com/davisp/ghp-import
+    license: Tumbolia Public License
+    summary: 'Copy your docs directly to the gh-pages branch.'

--- a/pelican/bld.bat
+++ b/pelican/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/pelican/build.sh
+++ b/pelican/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install install --single-version-externally-managed --record record.txt

--- a/pelican/meta.yaml
+++ b/pelican/meta.yaml
@@ -1,0 +1,48 @@
+package:
+    name: pelican
+    version: "3.3"
+
+source:
+    fn: pelican-3.3.tar.gz
+    url: https://pypi.python.org/packages/source/p/pelican/pelican-3.3.tar.gz
+    md5: 8aff3ca01631082372ab2305a874bb74
+
+build:
+    number: 0
+    entry_points:
+        - pelican = pelican:main
+        - pelican-import = pelican.tools.pelican_import:main
+        - pelican-quickstart = pelican.tools.pelican_quickstart:main
+        - pelican-themes = pelican.tools.pelican_themes:main
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+        - feedgenerator >=1.6
+        - jinja2 >=2.7
+        - pygments
+        - docutils
+        - pytz >=0a
+        - blinker
+        - unidecode
+        - six >=1.4
+        - python-dateutil
+        - ghp-import
+
+test:
+    imports:
+        - pelican
+        - pelican.tools
+    commands:
+        - pelican --help
+        - pelican-import --help
+        - pelican-quickstart --help
+        - pelican-themes --help
+
+about:
+    home: http://getpelican.com/
+    license: GNU Affero General Public License v3
+    summary: 'A tool to generate a static blog from reStructuredText or Markdown input files.'

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -33,7 +33,8 @@ echo "$config" > ~/.condarc
 # The lock file is stored in build_artefacts.
 conda clean --lock
 conda info
-unset LANG
+
+export LANG=en_US.UTF-8
 
 obvci_conda_build_dir.py /conda-recipes $UPLOAD_OWNER --build-condition "python >=2.7,<3|==3.4"
 


### PR DESCRIPTION
We need `pelican 3.3` to create the system-test webpage env.