### PR TITLE
Disable pygridgen on Python 3

### DIFF
--- a/pygridgen/meta.yaml
+++ b/pygridgen/meta.yaml
@@ -11,7 +11,7 @@ build:
 
 requirements:
     build:
-        - python
+        - python >=2.7,<3
         - numpy
     run:
         - python
@@ -23,7 +23,6 @@ requirements:
         - gridgen
         - gridutils
         - nn
-
 
 test:
     imports:

--- a/pygridtools/meta.yaml
+++ b/pygridtools/meta.yaml
@@ -11,7 +11,7 @@ build:
 
 requirements:
     build:
-        - python
+        - python >=2.7,<3
         - setuptools
     run:
         - gridgen


### PR DESCRIPTION
Until we fix `pygridgen` for Python 3.5 I am disabling the py3k builds.