### PR TITLE
Pygridtools from Geosyntec, new version

### DIFF
--- a/pygridgen/meta.yaml
+++ b/pygridgen/meta.yaml
@@ -18,7 +18,7 @@ requirements:
         - pandas
         - numpy
         - matplotlib
-        - basemap
+        - pyproj
         - csa
         - gridgen
         - gridutils

--- a/pygridtools/meta.yaml
+++ b/pygridtools/meta.yaml
@@ -1,10 +1,10 @@
 package:
     name: pygridtools
-    version: "0.1"
+    version: "0.2"
 
 source:
-    git_url: https://github.com/phobson/pygridtools.git
-    git_tag: 0.1
+    git_url: https://github.com/Geosyntec/pygridtools.git
+    git_tag: v0.2
 
 build:
     number: 0
@@ -16,13 +16,10 @@ requirements:
     run:
         - gridgen
         - fiona
-        - seaborn
         - python
         - pandas
         - numpy
         - matplotlib
-        - pyproj
-        - bokeh
         - pygridgen
 
 test:
@@ -34,6 +31,6 @@ test:
         - nose
 
 about:
-    home: https://github.com/phobson/pygridtools.git
+    home: https://github.com/Geosyntec/pygridtools.git
     license:  BSD License
-    summary: 'Python interface to gridgen by Pavel Sakov'
+    summary: 'Miscellaneous utilities built upon pygridgen'


### PR DESCRIPTION
Hey -- I made my employer the owner of the pygridtools library and upped the git tag to v0.2.

I also changed the dependencies of pygridgen  to skip basemap in favor of pyproj (should significantly reduce the build size and time).