### PR TITLE
Pin proj version

### DIFF
--- a/cartopy/meta.yaml
+++ b/cartopy/meta.yaml
@@ -17,9 +17,9 @@ requirements:
         - python
         - setuptools
         - six
-        - numpy
+        - numpy >=1.8,<1.10
         - cython
-        - proj4
+        - proj4 ==4.9.1  # [win]
         - geos
         # On OSX we need to effectively pin the geos version to the
         # one used by the specific shapely being targeted (we're letting
@@ -35,8 +35,8 @@ requirements:
         - nose
         - pillow
         - owslib
-        - numpy
-        - proj4
+        - numpy >=1.8,<1.10
+        - proj4 ==4.9.1  # [win]
         - geos
         - shapely >=1.5.9
         - scipy

--- a/proj4/bld.bat
+++ b/proj4/bld.bat
@@ -1,8 +1,3 @@
-nmake -f makefile.vc INSTDIR=%PREFIX%
-if errorlevel 1 exit 1
+nmake /f makefile.vc
 
-nmake -f makefile.vc INSTDIR=%PREFIX% install-all
-if errorlevel 1 exit 1
-
-move %PREFIX%\bin\*.* %PREFIX%
-if errorlevel 1 exit 1
+nmake INSTDIR=%LIBRARY_PREFIX% /f makefile.vc install-all

--- a/proj4/meta.yaml
+++ b/proj4/meta.yaml
@@ -1,24 +1,18 @@
 package:
     name: proj4
-    version: "4.9.2"
+    version: "4.9.1"
 
 source:
-    fn:  proj-4.9.2.tar.gz
-    url: http://download.osgeo.org/proj/proj-4.9.2.tar.gz
-    md5: 9843131676e31bbd903d60ae7dc76cf9
+    fn:  proj-4.9.1.tar.gz
+    url: http://download.osgeo.org/proj/proj-4.9.1.tar.gz
 
 build:
-    number: 0
+    number: 5
 
 requirements:
     run:
         # The VS version is important. See # https://github.com/SciTools/conda-recipes-scitools/issues/94.
         - python  # [win]
-
-test:
-    commands:
-        - echo -117 30 | cs2cs +proj=latlong +datum=NAD27 +to +proj=latlong +datum=NAD83
-        - echo -105 40 | proj +proj=utm +zone=13 +ellps=WGS84
 
 about:
     home: http://trac.osgeo.org/proj/


### PR DESCRIPTION
For some reason that escapes me `cartopy` fails to build on Windows with `proj 4.9.2`. 

In this PR I re-add `proj 4.9.1` just to issue a new release (`5`).  I had a broken release somewhere and it is easier to re-build it then to find which one and delete the binary.

I also pin `numpy` to avoid picking up `1.10.0` due to `ValueError: numpy.dtype has the wrong size, try recompiling`.  I guess we will have to avoid a little bit to use `numpy 1.10.0`.

Note that I will return the `proj 4.9.2` in another PR.  Both OSX and Linux cartopy seemed OK with the newer version.