### PR TITLE
Updated pyresample to 1.1.4

### DIFF
--- a/pyresample/meta.yaml
+++ b/pyresample/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: pyresample
-    version: "1.1.3"
+    version: "1.1.4"
 
 source:
-    fn: pyresample-1.1.3.tar.gz
-    url: https://pypi.python.org/packages/source/p/pyresample/pyresample-1.1.3.tar.gz
-    md5: a3c4ed7b3a5186b2ed397243f0b342f4
+    fn: pyresample-1.1.4.tar.gz
+    url: https://pypi.python.org/packages/source/p/pyresample/pyresample-1.1.4.tar.gz
+    md5: 57900c8d290ea61cd4af7954274d9bba
 
 build:
     number: 0


### PR DESCRIPTION
- Bugfix: Accept unicode proj4 strings. Fixes #24. [Martin Raspaud]
- Add python-configobj as a rpm requirement in setup.cfg. [Martin
  Raspaud]
- Add setup.cfg to allow rpm generation with bdist_rpm. [Martin Raspaud]
- Bugfix to address a numpy DeprecationWarning. [Martin Raspaud]
  Numpy won't take non-integer indices soon, so make index an int.