### PR TITLE
Rename proj4 to proj.4

### DIFF
--- a/cartopy/meta.yaml
+++ b/cartopy/meta.yaml
@@ -10,17 +10,16 @@ source:
         - cartopy.win.patch  # [win]
 
 build:
-    number: 1
+    number: 2
 
 requirements:
     build:
         - python
         - setuptools
         - six
-        - numpy >=1.8,<1.10
+        - numpy
         - cython
-        - proj4 ==4.9.1  # [win]
-        - proj4  # [not win]
+        - proj.4
         - geos
         # On OSX we need to effectively pin the geos version to the
         # one used by the specific shapely being targeted (we're letting
@@ -36,9 +35,8 @@ requirements:
         - nose
         - pillow
         - owslib
-        - numpy >=1.8,<1.10
-        - proj4 ==4.9.1  # [win]
-        - proj4  # [not win]
+        - numpy
+        - proj.4
         - geos
         - shapely >=1.5.9
         - scipy

--- a/cdo/build.sh
+++ b/cdo/build.sh
@@ -10,4 +10,9 @@
             --with-proj=$PREFIX
 
 make
+
+if [[ $(uname) == Linux ]]; then
+    make check
+fi
+
 make install

--- a/cdo/meta.yaml
+++ b/cdo/meta.yaml
@@ -8,19 +8,19 @@ source:
     md5: bf0997bf20e812f35e10188a930e24e2
 
 build:
-    number: 0
+    number: 1
 
 requirements:
     build:
         - jasper  # [not win]
         - ecmwf_grib  # [not win]
         - libnetcdf
-        - proj4
+        - proj.4
     run:
         - jasper  # [not win]
         - ecmwf_grib  # [not win]
         - libnetcdf
-        - proj4
+        - proj.4
 
 test:
     commands:

--- a/proj.4/bld.bat
+++ b/proj.4/bld.bat
@@ -1,0 +1,7 @@
+nmake /f makefile.vc
+
+nmake INSTDIR=%LIBRARY_PREFIX% /f makefile.vc install-all
+if errorlevel 1 exit 1
+
+move %LIBRARY_PREFIX%\bin\*.* %PREFIX%
+if errorlevel 1 exit 1

--- a/proj.4/build.sh
+++ b/proj.4/build.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
 ./configure --prefix=$PREFIX --without-jni
+
 make
+
+if [[ $(uname) == Linux ]]; then
+    make check
+fi
+
 make install

--- a/proj.4/meta.yaml
+++ b/proj.4/meta.yaml
@@ -1,14 +1,14 @@
 package:
-    name: proj4
-    version: "4.9.2"
+    name: proj.4
+    version: "4.9.1"
 
 source:
-    fn:  proj-4.9.2.tar.gz
-    url: http://download.osgeo.org/proj/proj-4.9.2.tar.gz
-    md5: 9843131676e31bbd903d60ae7dc76cf9
+    fn:  proj-4.9.1.tar.gz
+    url: http://download.osgeo.org/proj/proj-4.9.1.tar.gz
+    md5: 3cbb2a964fd19a496f5f4265a717d31c
 
 build:
-    number: 0
+    number: 1
 
 requirements:
     run:
@@ -17,8 +17,8 @@ requirements:
 
 test:
     commands:
-        - echo -117 30 | cs2cs +proj=latlong +datum=NAD27 +to +proj=latlong +datum=NAD83
         - echo -105 40 | proj +proj=utm +zone=13 +ellps=WGS84
+        - echo -117 30 | cs2cs +proj=latlong +datum=NAD27 +to +proj=latlong +datum=NAD83
 
 about:
     home: http://trac.osgeo.org/proj/

--- a/proj4/bld.bat
+++ b/proj4/bld.bat
@@ -1,8 +1,0 @@
-nmake -f makefile.vc INSTDIR=%PREFIX%
-if errorlevel 1 exit 1
-
-nmake -f makefile.vc INSTDIR=%PREFIX% install-all
-if errorlevel 1 exit 1
-
-move %PREFIX%\bin\*.* %PREFIX%
-if errorlevel 1 exit 1


### PR DESCRIPTION
The default channel uses the name `proj.4` instead of `proj4` (see https://github.com/ioos/conda-recipes/issues/413#issue-104850388).  That results in two versions of Proj.4 being installed depending on the package the users are trying to install.  I am renaming ours to reflect the same names found in the default channel in order to avoid that.

Note that we are using `proj.4 4.9.2` everywhere but cartopy on Windows.