### PR TITLE
Updated gridgen to 1.52.2

### DIFF
--- a/gridgen/meta.yaml
+++ b/gridgen/meta.yaml
@@ -1,10 +1,10 @@
 package:
     name: gridgen
-    version: "1.50.0"
+    version: "1.51.2"
 
 source:
     git_url: https://github.com/sakov/gridgen-c.git
-    git_tag: v1.50.0
+    git_tag: master
 
 build:
     number: 0


### PR DESCRIPTION
I guess we won't see releases, but the code is being updated.  Here is the changelog since the last version:

```
v. 1.51.2, 7 October 2015
        -- A bit of clean-up in sc_z2w().
v. 1.51.1, 5 October 2015
        -- Handled singularity in sc_prod() by adding test on absolute
           value of the argument of clog().
v. 1.51.0, 2 October 2015
        -- Added a new option: taking care of geographic coordinates. If there
           is entry "geographic <lon0> <lat0>" in the parameter file then the
           input coordinates are assumed to be geographic. They are internally
           converted to stereographic projection with the South Pole at
           (<lon0>, <lat0>) and converted back during the output of the grid
           nodes.
v. 1.50, 25 September 2015
        -- Minor changes to makefile.in: added $(LDFLAGS) for target
           `libgridgen.so' (thanks to @ocefpaf for pointing), and removed
           target `dist'
```