### PR TITLE
Update pytest-django to 2.9.1

### DIFF
--- a/pytest-django/meta.yaml
+++ b/pytest-django/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: pytest-django
-    version: "2.8.0"
+    version: "2.9.1"
 
 source:
-    fn: pytest-django-2.8.0.tar.gz
-    url: https://pypi.python.org/packages/source/p/pytest-django/pytest-django-2.8.0.tar.gz
-    md5: ad08caca77086f4f2692d1284c07eff3
+    fn: pytest-django-2.9.1.tar.gz
+    url: https://pypi.python.org/packages/source/p/pytest-django/pytest-django-2.9.1.tar.gz
+    md5: 3c9dde85e99ec409df209a62b4715e1a
 
 build:
     preserve_egg_dir: True
@@ -15,6 +15,7 @@ requirements:
     build:
         - python
         - setuptools
+        - setuptools_scm
     run:
         - python
         - pytest >=2.5


### PR DESCRIPTION
Changelog
=========
2.9.1
-----

Bug fixes
^^^^^^^^^

* Fix regression introduced in 2.9.0 that caused TestCase subclasses with
  mixins to cause errors. Thanks MikeVL for `the bug report
  <https://github.com/pytest-dev/pytest-django/issues/280>`_.


2.9.0
-----

2.9.0 focus on compatibility with Django 1.9 and master as well as pytest 2.8.1
and Python 3.5

Features
^^^^^^^^
* `--fail-on-template-vars` - fail tests for invalid variables in templates.
  Thanks to Johannes Hoppe for idea and implementation. Thanks Daniel Hahler
  for review and feedback.

Bug fixes
^^^^^^^^^
* Ensure urlconf is properly reset when using @pytest.mark.urls. Thanks to
  Sarah Bird, David Szotten, Daniel Hahler and Yannick PÉROUX for patch and
  discussions. Fixes `issue #183
  <https://github.com/pytest-dev/pytest-django/issues/183>`_.

* Call `setUpClass()` in Django `TestCase` properly when test class is
  inherited multiple places. Thanks to Benedikt Forchhammer for report and
  initial test case. Fixes `issue #265 <https://github.com/pytest-dev/pytest-django/issues/265>`_.

Compatibility
^^^^^^^^^^^^^

* Settings defined in `pytest.ini`/`tox.ini`/`setup.cfg` used to override
  `DJANGO_SETTINGS_MODULE` defined in the environment. Previously the order was
  undocumented. Now, instead the settings from the environment will be used
  instead. If you previously relied on overriding the environment variable,
  you can instead specify `addopts = --ds=yourtestsettings` in the ini-file
  which will use the test settings. See `PR #199
  <https://github.com/pytest-dev/pytest-django/pull/199>`_.

* Support for Django 1.9.

* Support for Django master (to be 1.10) as of 2015-10-06.

* Drop support for Django 1.3. While pytest-django supports a wide range of
  Django versions, extended for Django 1.3 was dropped in february 2013.