### PR TITLE
Updated pycsw to 1.10.3

### DIFF
--- a/pycsw/build.sh
+++ b/pycsw/build.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
 $PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.

--- a/pycsw/meta.yaml
+++ b/pycsw/meta.yaml
@@ -1,24 +1,18 @@
 package:
     name: pycsw
-    version: "1.10.2"
+    version: "1.10.3"
 
 source:
     git_url: https://github.com/geopython/pycsw.git
-    git_tag: 1.10.2
+    git_tag: 1.10.3
+
 build:
-    number: 2
+    number: 0
     preserve_egg_dir: True
 
 requirements:
     build:
         - python >=2.7,<3
-        - setuptools
-        - sqlalchemy
-        - geolinks
-        - lxml
-        - owslib
-        - pyproj
-        - shapely
     run:
         - python
         - sqlalchemy


### PR DESCRIPTION
The 1.10.3 release is a maintenance release, addressing the following fixes:

- enhance ISO 19119 link parsing for srv:serviceType
- centralize XML parser across codebase
