### PR TITLE
Downgrade conda build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,12 @@ before_install:
 install:
     # Download and run bootstrap.
     - wget https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py
-    - python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 2 --without-obvci && source ~/miniconda/bin/activate root
+    - python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
     - conda config --set show_channel_urls True
     - conda install -c http://conda.binstar.org/pelson/channel/development --yes --quiet obvious-ci
     - conda config --add channels ioos
     - obvci_install_conda_build_tools.py
+    - conda install --yes conda-build==1.18.0
 
 script:
     - obvci_conda_build_dir.py ./ ioos --channel main --build-condition "python >=2.7,<3|==3.4"


### PR DESCRIPTION
Latest conda-build introduced a [bug](https://travis-ci.org/ioos/conda-recipes/builds/85940423#L2326) that I believe is already fixed [here](https://github.com/conda/conda-build/commit/b758f1b1ac0c3efbb4d5cc486ab54270595356b4), but we need to downgrade conda-build until Continuum issues a new release.

Ping @pelson in case you get hit by this.