### PR TITLE
Updated xray to 0.6.1

### DIFF
--- a/xray/meta.yaml
+++ b/xray/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: xray
-    version: "0.6.0"
+    version: "0.6.1"
 
 source:
-    fn: xray-0.6.0.tar.gz
-    url: https://pypi.python.org/packages/source/x/xray/xray-0.6.0.tar.gz
-    md5: f6331054e509b92e7f87b0db1cb84954
+    fn: xray-0.6.1.tar.gz
+    url: https://pypi.python.org/packages/source/x/xray/xray-0.6.1.tar.gz
+    md5: 7d5e0e3ba365017d7a8b6542c48c4ce6
 
 build:
     number: 0
@@ -21,7 +21,7 @@ requirements:
         - netcdf4
         - scipy
         - bottleneck  # [not py35]
-        - dask
+        - dask >=0.6
         - h5netcdf
         - cyordereddict
 


### PR DESCRIPTION
```
What's New
==========

v0.6.1 (21 October 2015)
------------------------

This release contains a number of bug and compatibility fixes, as well
as enhancements to plotting, indexing and writing files to disk.

Note that the minimum required version of dask for use with xray is now
version 0.6.

API Changes

- The handling of colormaps and discrete color lists for 2D plots in
  :py:meth:`~xray.DataArray.plot` was changed to provide more compatibility
  with matplotlib's ``contour`` and ``contourf`` functions (:issue:`538`).
  Now discrete lists of colors should be specified using ``colors`` keyword,
  rather than ``cmap``.

Enhancements

- Faceted plotting through :py:class:`~xray.plot.FacetGrid` and the
  :py:meth:`~xray.plot.plot` method. See :ref:`plotting.faceting` for more details
  and examples.
- :py:meth:`~xray.Dataset.sel` and :py:meth:`~xray.Dataset.reindex` now support
  the ``tolerance`` argument for controlling nearest-neighbor selection
  (:issue:`629`):

  .. ipython::
    :verbatim:

    In [5]: array = xray.DataArray([1, 2, 3], dims='x')

    In [6]: array.reindex(x=[0.9, 1.5], method='nearest', tolerance=0.2)
    Out[6]:
    <xray.DataArray (x: 2)>
    array([  2.,  nan])
    Coordinates:
      * x        (x) float64 0.9 1.5

  This feature requires pandas v0.17 or newer.
- New ``encoding`` argument in :py:meth:`~xray.Dataset.to_netcdf` for writing
  netCDF files with compression, as described in the new documentation
  section on :ref:`io.netcdf.writing_encoded`.
- Add :py:attr:`~xray.Dataset.real` and :py:attr:`~xray.Dataset.imag`
  attributes to Dataset and DataArray (:issue:`553`).
- More informative error message with :py:meth:`~xray.Dataset.from_dataframe`
  if the frame has duplicate columns.
- xray now uses deterministic names for dask arrays it creates or opens from
  disk. This allows xray users to take advantage of dask's nascent support for
  caching intermediate computation results. See :issue:`555` for an example.

Bug fixes

- Forwards compatibility with the latest pandas release (v0.17.0). We were
  using some internal pandas routines for datetime conversion, which
  unfortunately have now changed upstream (:issue:`569`).
- Aggregation functions now correctly skip ``NaN`` for data for ``complex128``
  dtype (:issue:`554`).
- Fixed indexing 0d arrays with unicode dtype (:issue:`568`).
- :py:meth:`~xray.DataArray.name` and Dataset keys must be a string or None to
  be written to netCDF (:issue:`533`).
- :py:meth:`~xray.DataArray.where` now uses dask instead of numpy if either the
  array or ``other`` is a dask array. Previously, if ``other`` was a numpy array
  the method was evaluated eagerly.
- Global attributes are now handled more consistently when loading remote
  datasets using ``engine='pydap'`` (:issue:`574`).
- It is now possible to assign to the ``.data`` attribute of DataArray objects.
- ``coordinates`` attribute is now kept in the encoding dictionary after
  decoding (:issue:`610`).
- Compatibility with numpy 1.10 (:issue:`617`).
```