### PR TITLE
Latest netCDF4-python compiled with Cython

### DIFF
--- a/netcdf4/build.sh
+++ b/netcdf4/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+SETUPCFG=$SRC_DIR\setup.cfg
+
+echo "[options]" > $SETUPCFG
+echo "use_cython=True" >> $SETUPCFG
+echo "[directories]" >> $SETUPCFG
+echo "netCDF4_dir = $PREFIX" >> $SETUPCFG
+
+${PYTHON} setup.py install --single-version-externally-managed --record record.txt

--- a/netcdf4/meta.yaml
+++ b/netcdf4/meta.yaml
@@ -1,0 +1,43 @@
+package:
+    name: netcdf4
+    version: "1.2.1"
+
+source:
+    fn: netCDF4-1.2.1.tar.gz
+    url: https://pypi.python.org/packages/source/n/netCDF4/netCDF4-1.2.1.tar.gz
+    md5: 9d9a7015ee98ec6766adc811d95b82c3
+
+build:
+    number: 0
+    entry_points:
+        - ncinfo = netCDF4.utils:ncinfo
+        - nc4tonc3 = netCDF4.utils:nc4tonc3
+        - nc3tonc4 = netCDF4.utils:nc3tonc4
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - numpy >=1.7
+        - cython
+        - hdf5
+        - libnetcdf
+    run:
+        - python
+        - numpy >=1.7
+        - hdf5
+        - libnetcdf
+
+test:
+    imports:
+        - netCDF4
+        - netcdftime
+    commands:
+        - ncinfo -h
+        - nc4tonc3 -h
+        - nc3tonc4 -h
+
+about:
+    home: http://github.com/Unidata/netcdf4-python
+    license: OSI Approved
+    summary: 'Provides an object-oriented python interface to the netCDF version 4 library.'

--- a/netcdf4/run_test.py
+++ b/netcdf4/run_test.py
@@ -1,0 +1,5 @@
+import netCDF4
+
+url = 'http://test.opendap.org:80/opendap/data/ncml/sample_virtual_dataset.ncml'
+nc = netCDF4.Dataset(url)
+print(nc.filepath())


### PR DESCRIPTION
This PR fixes two problems with the default channel netCDF4-python

- compiles it with cython so we can use the `.filepath()` method
- Updates to 1.2.1 (the default channel is stuck at `1.1.9`)

```
 version 1.2.1 (tag v1.2.1rel)
 =============================
 * add the capability to slice variables with unsorted integer sequences,
   or integer sequences with duplicates (issue #467). This was done
   by converting boolean array slices to integer array slices internally,
   instead of the other way around.
 * raise TypeError if masked array assigned to a VLEN str variable slice
   (issue #464).
 * Ellipsis now can be used with scalar VLEN str variables (issue #458).
   Slicing of scalar VLEN (non-str) variables now works.
 * Allow non-positive reference years in non-real-world calendars
   (issue #442).

 version 1.2.0 (tag v1.2.0rel)
 =============================
 * Fixes to setup.py for building on windows (issue #460).
 * warnings now issued if file being read contains unsupported
   variables or data types (they were previously being silently
   skipped).
 * added 'get_variables_by_attributes' method (issue #454).
 * check for 'units' attribute in date2index (issue #453).
 * added support for enum types (issue #452).
 * added 'isopen' Dataset method (issue #450).
 * raise ValueError if year 0 or negative year used in time units string.
   The year 0 does not exist in the Julian and Gregorian
   calendars (issue #442).
```