### PR TITLE
Added conda-execute

### DIFF
--- a/conda-execute/bld.bat
+++ b/conda-execute/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed  --record record.txt
+if errorlevel 1 exit 1

--- a/conda-execute/build.sh
+++ b/conda-execute/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed  --record record.txt
+

--- a/conda-execute/meta.yaml
+++ b/conda-execute/meta.yaml
@@ -1,0 +1,30 @@
+package:
+    name: conda-execute
+    version: 0.4.0
+
+source:
+    git_url: https://github.com/pelson/conda-execute.git
+    git_tag: v0.4.0
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+        - yaml
+        - conda
+        - psutil
+
+test:
+    imports:
+        - conda_execute
+    commands:
+        - conda execute --help
+        - conda tmpenv --help
+
+about:
+    home: https://github.com/pelson/conda-execute
+    license: BSD
+    summary: 'Execute scripts in isolated temporary environments.'
+


### PR DESCRIPTION
@pelson I wanted to avoid the duplication, but it seems that conda is forcing us in the wrong direction:

```shell
> anaconda copy conda-forge/conda-execute/0.4.0 --to-owner ioos
Using anaconda-server api site https://api.anaconda.org
[ServerError] Copying anaconda packages temporarily disabled.
This issue is being tracked here:
https://github.com/Anaconda-Server/docs.anaconda.org/issues/119 
```

At least it is "temporarily."