### PR TITLE
no mocsy on py3k

### DIFF
--- a/mocsy/meta.yaml
+++ b/mocsy/meta.yaml
@@ -8,11 +8,10 @@ source:
 
 build:
     number: 0
-    #skip: True  # [win]
 
 requirements:
     build:
-        - python
+        - python >=2.7,<3
         - setuptools
         - mingwpy  # [win]
         - numpy


### PR DESCRIPTION
There is a compiler issue when building `mocsy` for Python 3  om Windows.

NB: `mocsy` does work with Python3 though.

```python
running build_ext
Traceback (most recent call last):
  File "setup.py", line 59, in <module>
    maintainer_email='ocefpaf@gmail.com',
  File "C:\conda\envs\_build\lib\site-packages\numpy\distutils\core.py", line 169, in setup
    return old_setup(**new_attr)
  File "C:\conda\envs\_build\lib\distutils\core.py", line 148, in setup
    dist.run_commands()
  File "C:\conda\envs\_build\lib\distutils\dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "C:\conda\envs\_build\lib\distutils\dist.py", line 974, in run_command
    cmd_obj.run()
  File "C:\conda\envs\_build\lib\site-packages\numpy\distutils\command\install.py", line 62, in run
    r = self.setuptools_run()
  File "C:\conda\envs\_build\lib\site-packages\numpy\distutils\command\install.py", line 36, in setuptools_run
    return distutils_install.run(self)
  File "C:\conda\envs\_build\lib\distutils\command\install.py", line 539, in run
    self.run_command('build')
  File "C:\conda\envs\_build\lib\distutils\cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "C:\conda\envs\_build\lib\distutils\dist.py", line 974, in run_command
    cmd_obj.run()
  File "C:\conda\envs\_build\lib\site-packages\numpy\distutils\command\build.py", line 47, in run
    old_build.run(self)
  File "C:\conda\envs\_build\lib\distutils\command\build.py", line 126, in run
    self.run_command(cmd_name)
  File "C:\conda\envs\_build\lib\distutils\cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "C:\conda\envs\_build\lib\distutils\dist.py", line 974, in run_command
    cmd_obj.run()
  File "C:\conda\envs\_build\lib\site-packages\numpy\distutils\command\build_ext.py", line 117, in run
    force=self.force)
  File "C:\conda\envs\_build\lib\site-packages\numpy\distutils\ccompiler.py", line 596, in new_compiler
    compiler = klass(None, dry_run, force)
  File "C:\conda\envs\_build\lib\site-packages\numpy\distutils\mingw32ccompiler.py", line 58, in __init__
    dry_run, force)
  File "C:\conda\envs\_build\lib\distutils\cygwinccompiler.py", line 126, in __init__
    if self.ld_version >= "2.10.90":
TypeError: unorderable types: NoneType() >= str()
 
C:\conda\conda-bld\work>if errorlevel 1 exit 1 
Command failed: C:\windows\system32\cmd.exe /c call bld.bat
```