### PR TITLE
Updated iso8601 to 0.1.11

### DIFF
--- a/iso8601/bld.bat
+++ b/iso8601/bld.bat
@@ -1,2 +1,2 @@
-"%PYTHON%" setup.py install
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1

--- a/iso8601/build.sh
+++ b/iso8601/build.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/iso8601/meta.yaml
+++ b/iso8601/meta.yaml
@@ -1,14 +1,14 @@
 package:
     name: iso8601
-    version: "0.1.10"
+    version: "0.1.11"
 
 source:
-    fn: iso8601-0.1.10.tar.gz
-    url: https://pypi.python.org/packages/source/i/iso8601/iso8601-0.1.10.tar.gz
-    md5: 23acb1029acfef9c32069c6c851c3a41
+    fn: iso8601-0.1.11.tar.gz
+    url: https://pypi.python.org/packages/source/i/iso8601/iso8601-0.1.11.tar.gz
+    md5: b06d11cd14a64096f907086044f0fe38
 
 build:
-    number: 1
+    number: 0
 
 requirements:
     build:


### PR DESCRIPTION
Changes 0.1.11
- Remove logging (thanks to Quentin Pradet in https://bitbucket.org/micktwomey/pyiso8601/pull-requests/6/remove-debug-logging/diff)
- Add support for , as separator for fractional part (thanks to ecksun in https://bitbucket.org/micktwomey/pyiso8601/pull-requests/5/add-support-for-as-separator-for/diff)
- Add Python 3.4 and 3.5 to tox test config.
- Add PyPy 3 to tox test config.
- Link to documentation at http://pyiso8601.readthedocs.org/