### PR TITLE
Updated djangorestframework to 3.3.1

### DIFF
--- a/djangorestframework/meta.yaml
+++ b/djangorestframework/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: djangorestframework
-    version: "3.2.4"
+    version: "3.3.1"
 
 source:
-    fn: djangorestframework-3.2.4.tar.gz
-    url: https://pypi.python.org/packages/source/d/djangorestframework/djangorestframework-3.2.4.tar.gz
-    md5: cc0f04af37ad4017e9f306d7f6940143
+    fn: djangorestframework-3.3.1.tar.gz
+    url: https://pypi.python.org/packages/source/d/djangorestframework/djangorestframework-3.3.1.tar.gz
+    md5: 4eedf30c17dff67518f81b090bc357d0
 
 build:
     number: 0
@@ -22,7 +22,7 @@ test:
         - rest_framework
         - rest_framework.authtoken
         - rest_framework.authtoken.migrations
-        - rest_framework.authtoken.south_migrations
+        #- rest_framework.authtoken.south_migrations
         - rest_framework.templatetags
         - rest_framework.utils
 


### PR DESCRIPTION
### 3.3.1

**Date**: [4th November 2015][3.3.1-milestone].

* Resolve parsing bug when accessing `request.POST` ([#3592][gh3592])
* Correctly deal with `to_field` referring to primary key. ([#3593][gh3593])
* Allow filter HTML to render when no `filter_class` is defined. ([#3560][gh3560])
* Fix admin rendering issues. ([#3564][gh3564], [#3556][gh3556])
* Fix issue with DecimalValidator. ([#3568][gh3568])

### 3.3.0

**Date**: [28th October 2015][3.3.0-milestone].

* HTML controls for filters. ([#3315][gh3315])
* Forms API. ([#3475][gh3475])
* AJAX browsable API. ([#3410][gh3410])
* Added JSONField. ([#3454][gh3454])
* Correctly map `to_field` when creating `ModelSerializer` relational fields. ([#3526][gh3526])
* Include keyword arguments when mapping `FilePathField` to a serializer field. ([#3536][gh3536])
* Map appropriate model `error_messages` on `ModelSerializer` uniqueness constraints. ([#3435][gh3435])
* Include `max_length` constraint for `ModelSerializer` fields mapped from TextField. ([#3509][gh3509])
* Added support for Django 1.9. ([#3450][gh3450], [#3525][gh3525])
* Removed support for Django 1.5 & 1.6. ([#3421][gh3421], [#3429][gh3429])
* Removed 'south' migrations. ([#3495][gh3495])

## 3.2.x series

### 3.2.5

**Date**: [27th October 2015][3.2.5-milestone].

* Escape `username` in optional logout tag. ([#3550][gh3550])