### PR TITLE
Updated django-extensions to 1.5.9

### DIFF
--- a/django-extensions/meta.yaml
+++ b/django-extensions/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: django-extensions
-    version: "1.5.7"
+    version: "1.5.9"
 
 source:
-    fn: django-extensions-1.5.7.tar.gz
-    url: https://pypi.python.org/packages/source/d/django-extensions/django-extensions-1.5.7.tar.gz
-    md5: 848bd98759ea32cf58f4977cd41e7cad
+    fn: django-extensions-1.5.9.tar.gz
+    url: https://pypi.python.org/packages/source/d/django-extensions/django-extensions-1.5.9.tar.gz
+    md5: f36493496ca4b10a3de4959db07e2d8e
 
 build:
     number: 0


### PR DESCRIPTION
Changelog
=========

1.5.9
-----

Changes:
 - Fix: wheel still had the old migrations directory in the package


1.5.8
-----

Changes:
 - Fix: migrations, fix BadMigrationError with Django 1.8+
 - Fix: reset_db, Django 1.8+ compatibility fix
 - Fix: runserver_plus, fix signature of null_technical_500_response for Django 1.8+
 - Fix: graph_models, use force_bytes instead of .decode('utf8')
 - Improvement: print_settings, add format option to only print values
 - Improvement: print_esttings, add format option for simple key = value text output
 - Improvement: email_export, documentation updates
 - Improvement: shell_plus, auto load conditional db expressions Case and When