### PR TITLE
Updated numdifftools 0.9.13

### DIFF
--- a/numdifftools/meta.yaml
+++ b/numdifftools/meta.yaml
@@ -1,29 +1,27 @@
 package:
     name: numdifftools
-    version: "0.9.12"
+    version: "0.9.13"
 
 source:
-    fn: numdifftools-0.9.12.zip
-    url: https://pypi.python.org/packages/source/N/Numdifftools/numdifftools-0.9.12.zip
-    md5: f1c3a80a08ca6ca21d7a8966ca5a97b0
+    fn: numdifftools-0.9.13.zip
+    url: https://pypi.python.org/packages/source/N/Numdifftools/numdifftools-0.9.13.zip
+    md5: 86295fdf387780028ffc97eecdc9dce9
 
 build:
     number: 0
 
 requirements:
     build:
-        - python >=2.7,<3
+        - python
         - setuptools
         - setuptools_scm
+        - pyscaffold >=2.4rc1,<2.5a0
         - six
     run:
         - python
         - numpy
-        - matplotlib
         - scipy
         - algopy
-        - numpydoc
-        - sphinx_rtd_theme
         - six
 
 test:
@@ -32,7 +30,7 @@ test:
         - numdifftools.tests
     requires:
         - pytest
-        - pytest-cov
+        - pytest-cov  # [not py3k]
 
 about:
     home: https://github.com/pbrod/numdifftools/

--- a/pbr/bld.bat
+++ b/pbr/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/pbr/build.sh
+++ b/pbr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/pbr/meta.yaml
+++ b/pbr/meta.yaml
@@ -1,0 +1,49 @@
+package:
+    name: pbr
+    version: "1.8.1"
+
+source:
+    fn: pbr-1.8.1.tar.gz
+    url: https://pypi.python.org/packages/source/p/pbr/pbr-1.8.1.tar.gz
+    md5: c8f9285e1a4ca6f9654c529b158baa3a
+
+build:
+    number: 0
+    preserve_egg_dir: True
+    entry_points:
+        - pbr = pbr.cmd.main:main
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+
+test:
+    imports:
+        - pbr
+        - pbr.cmd
+        - pbr.hooks
+        #- pbr.tests
+    commands:
+        - pbr --help
+    requires:
+        - coverage >=3.6
+        #- discover
+        #- fixtures >=1.3.1
+        #- hacking <0.11,>=0.10.0
+        #- mock >=1.2
+        #- python-subunit >=0.0.18
+        - six >=1.9.0
+        - sphinx !=1.2.0,!=1.3b1,<1.3,>=1.1.2
+        #- testrepository >=0.0.18
+        #- testresources >=0.2.4
+        #- testscenarios >=0.4
+        #- testtools >=1.4.0
+        - virtualenv
+
+about:
+    home: https://launchpad.net/pbr
+    license: Apache Software License
+    summary: 'Python Build Reasonableness'

--- a/pyscaffold/bld.bat
+++ b/pyscaffold/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/pyscaffold/build.sh
+++ b/pyscaffold/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/pyscaffold/meta.yaml
+++ b/pyscaffold/meta.yaml
@@ -1,0 +1,43 @@
+package:
+    name: pyscaffold
+    version: "2.4.4"
+
+source:
+    fn: pyscaffold-2.4.4.tar.gz
+    url: https://pypi.python.org/packages/source/P/PyScaffold/pyscaffold-2.4.4.tar.gz
+    md5: 647ffe3bcd0454990e80aef291eea6ce
+
+build:
+    number: 0
+    preserve_egg_dir: True
+    entry_points:
+        - putup=pyscaffold.cli:run
+
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - setuptools_scm >=1.7
+        - six
+        - pbr >=1.6
+    run:
+        - python
+        - six
+        - pbr >=1.6
+
+test:
+    imports:
+        - pyscaffold
+        #- pyscaffold.contrib
+        - pyscaffold.templates
+    commands:
+        - putup --help
+    requires:
+        - pytest
+        - pytest-cov  # [not py3k]
+
+about:
+    home: http://pyscaffold.readthedocs.org/
+    license: BSD License
+    summary: 'Template tool for putting up the scaffold of a Python project'


### PR DESCRIPTION
=========
Changelog
=========

Created with gitcommand: git shortlog v0.9.12..v0.9.13


Version 0.9.13, October 30, 2015
---------------------------------

pbrod (21):
      * Updated README.rst and CHANGES.rst.
      * updated Limits.
      * Made it possible to differentiate complex functions and allow zero'th order derivative.
      * BUG: added missing derivative order, n to Gradient, Hessian, Jacobian.
      * Made test more robust.
      * Updated structure in setup according to pyscaffold version 2.4.2.
      * Updated setup.cfg and deleted duplicate tests folder.
      * removed unused code.
      * Added appveyor.yml.
      * Added required appveyor install scripts
      * Fixed bug in appveyor.yml.
      * added wheel to requirements.txt.
      * updated appveyor.yml.
      * Removed import matplotlib.

Justin Lecher (1):
      * Fix min version for numpy.

kikocorreoso (1):
      * fix some prints on run_benchmark.py to make it work with py3