### PR TITLE
update geopy to 1.11.0

### DIFF
--- a/geopy/meta.yaml
+++ b/geopy/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: geopy
-    version: "1.10.0"
+    version: "1.11.0"
 
 source:
-    fn: geopy-1.10.0.tar.gz
-    url: https://pypi.python.org/packages/source/g/geopy/geopy-1.10.0.tar.gz
-    md5: 57cab8fd885a88ad4acecc53346e4c39
+    fn: geopy-1.11.0.tar.gz
+    url: https://pypi.python.org/packages/source/g/geopy/geopy-1.11.0.tar.gz
+    md5: b73445dc0069550bbd2b09162f7339b3
 
 build:
     number: 0
@@ -24,8 +24,6 @@ test:
     requires:
         - mock
         - pylint
-        #- nose-cov
-        #- tox
 
 about:
     home: https://github.com/geopy/geopy


### PR DESCRIPTION
* ADDED: Photon geocoder. Contributed by mthh.
* ADDED: Bing supports structured query parameters. Contributed by
    SemiNormal.

* CHANGED: Geocoders send a `User-Agent` header, which by default is
    `geopy/1.11.0`. Configure it during geocoder initialization. Contributed
    by sebastianneubauer.

* FIXED: Index out of range error with no results using Yandex. Contributed
    by facciocose.

* FIXED: Nominatim was incorrectly sending `view_box` when not requested,
    and formatting it incorrectly. Contributed by m0zes.