### PR TITLE
Skip pylint on py35+win64

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ install:
     # Set the CONDA_NPY, although it has no impact on the actual build. We need this because of a test within conda-build.
     - cmd: set CONDA_NPY=19
     - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% 2 --without-obvci
+    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% 3 --without-obvci
     - cmd: set CONDA_PY=%CONDA_PY%
     - cmd: set PATH=%PATH%;%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts
     - cmd: set PYTHONUNBUFFERED=1

--- a/geopy/meta.yaml
+++ b/geopy/meta.yaml
@@ -23,7 +23,7 @@ test:
         - geopy.geocoders
     requires:
         - mock
-        - pylint
+        - pylint  # [not win64 and not py35]
 
 about:
     home: https://github.com/geopy/geopy


### PR DESCRIPTION
Some Windows packages are inconsistent in the default channel.  Since `pylint` is used only for testing I am just skipping it for now.