### PR TITLE
Switch to release

### DIFF
--- a/folium/meta.yaml
+++ b/folium/meta.yaml
@@ -3,11 +3,12 @@ package:
     version: "0.1.6"
 
 source:
-    git_url: https://github.com/python-visualization/folium.git
-    git_tag: v0.1.6
+    fn: folium-0.1.6.tar.gz
+    url: https://pypi.python.org/packages/source/f/folium/folium-0.1.6.tar.gz
+    md5: 96e76012d2517a376f2805a4860f8d1e
 
 build:
-    number: 1
+    number: 2
 
 requirements:
     build:

--- a/ulmo/meta.yaml
+++ b/ulmo/meta.yaml
@@ -9,6 +9,7 @@ source:
 
 build:
     number: 0
+    skip: True  # [py35 and win64]
 
 requirements:
     build:


### PR DESCRIPTION
I used an unreleased tag before. This is the final `v0.1.6`.

### v0.1.6

- Added default options to tile_layer (ozak 1ad2336)
- Introduce free scale for geo_json (Nikolay Koldunov 21e2757)
- Added Image Overlay. (andrewgiessel b625613)
- All popups can take a `popup_width` keyword to adjust the width in
  text/HTML (ocefpaf 157).
- CAVEAT! Backwards incompatibly change: the keyword `width` in popups is now
  `popup_width` to avoid confusion with map `width`.
- Simpler HTML repr (ocefpaf a343106)

##### Bug Fixes
- WMS layer (Martin Journois 610b42d)
- Stamentoner URL (ocefpaf 7003dc5)