### PR TITLE
Skip Windows 64 + Python 3.5

### DIFF
--- a/geopandas/meta.yaml
+++ b/geopandas/meta.yaml
@@ -9,6 +9,7 @@ source:
 
 build:
     skip: True  # [py35 and osx]
+    skip: True  # [py35 and win64]
     number: 1
 
 requirements:

--- a/paegan-transport/meta.yaml
+++ b/paegan-transport/meta.yaml
@@ -9,6 +9,7 @@ source:
 
 build:
     number: 0
+    skip: True  # [py35 and win64]
 
 requirements:
     build:

--- a/pyoos/meta.yaml
+++ b/pyoos/meta.yaml
@@ -12,16 +12,8 @@ build:
 
 requirements:
     build:
-        - python
+        - python  >=2.7,<3
         - setuptools
-        - numpy
-        - paegan
-        - owslib
-        - requests
-        - fiona
-        - beautifulsoup4
-        - lxml
-        - pytest
     run:
         - python
         - paegan
@@ -31,15 +23,14 @@ requirements:
         - fiona
         - beautifulsoup4
         - lxml
-        - pytest
 
 test:
     imports:
         - tests
+        - pyoos
         - pyoos.parsers
         - pyoos.collectors.nerrs
         - pyoos.collectors
-        - pyoos
         - pyoos.collectors.hads
         - pyoos.collectors.coops
         - pyoos.collectors.ndbc
@@ -51,6 +42,8 @@ test:
         - pyoos.utils
         - pyoos.collectors.awc
         - pyoos.collectors.wqp
+    requires:
+        - pytest
 
 about:
     home: https://github.com/asascience-open/pyoos

--- a/xray/meta.yaml
+++ b/xray/meta.yaml
@@ -9,6 +9,7 @@ source:
 
 build:
     number: 0
+    skip: True  # [py35 and win64]
 
 requirements:
     build:


### PR DESCRIPTION
Some missing dependency is preventing some build on Windows64+Python 3.5

See #588 