### PR TITLE
Skip Pyoos on Python 3

### DIFF
--- a/pyoos/bld.bat
+++ b/pyoos/bld.bat
@@ -1,2 +1,2 @@
-"%PYTHON%" setup.py install
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1

--- a/pyoos/build.sh
+++ b/pyoos/build.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/pyoos/meta.yaml
+++ b/pyoos/meta.yaml
@@ -3,8 +3,8 @@ package:
     version: "0.6.2"
 
 source:
-    git_url: https://github.com/ioos/pyoos.git
-    git_tag: 0.6.2
+    git_url: https://github.com/ocefpaf/pyoos.git
+    git_tag: fix_travis
 
 build:
     number: 1
@@ -12,7 +12,7 @@ build:
 
 requirements:
     build:
-        - python  >=2.7,<3
+        - python >=2.7,<3
         - setuptools
     run:
         - python


### PR DESCRIPTION
Pyoos builds but is not Python 3 compat.

NB: I am building for the PR https://github.com/ioos/pyoos/pull/49 to avoid importing pyoos at build time.