### PR TITLE
Add Linux recipes for ESMF and ESMPy

### DIFF
--- a/esmf/build.sh
+++ b/esmf/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+
+export ESMF_DIR=`pwd`
+export ESMF_INSTALL_PREFIX=${PREFIX}
+export ESMF_NETCDF="split"
+export ESMF_NETCDF_INCLUDE=${PREFIX}/include
+export ESMF_NETCDF_LIBPATH=${PREFIX}/lib
+export ESMF_COMM=mpich2
+
+make  -j ${CPU_COUNT}
+# TODO (bekozi): Enable all ESMF tests.
+#make all_tests | tee ~/esmf_all_tests.out
+make install

--- a/esmf/build.sh
+++ b/esmf/build.sh
@@ -9,6 +9,6 @@ export ESMF_NETCDF_LIBPATH=${PREFIX}/lib
 export ESMF_COMM=mpich2
 
 make  -j ${CPU_COUNT}
-# TODO (bekozi): Enable all ESMF tests.
-#make all_tests | tee ~/esmf_all_tests.out
+# TODO (bekozi): Enable ESMF tests?
+#make all_tests
 make install

--- a/esmf/meta.yaml
+++ b/esmf/meta.yaml
@@ -6,7 +6,6 @@ build:
   number: 0
   skip: True # [osx]
   skip: True # [win]
-  skip: True # [py3k]
 
 source:
   git_url: git://git.code.sf.net/p/esmf/esmf

--- a/esmf/meta.yaml
+++ b/esmf/meta.yaml
@@ -4,9 +4,6 @@ package:
 
 build: 
   number: 0
-  rpaths:
-    - lib/
-    - lib64/
   skip: True # [osx]
   skip: True # [win]
   skip: True # [py3k]

--- a/esmf/meta.yaml
+++ b/esmf/meta.yaml
@@ -1,0 +1,29 @@
+package:
+  name: esmf
+  version: 6.3.0rp1
+
+build: 
+  number: 0
+  rpaths:
+    - lib/
+    - lib64/
+  skip: True # [osx]
+  skip: True # [win]
+  skip: True # [py3k]
+
+source:
+  git_url: git://git.code.sf.net/p/esmf/esmf
+  git_tag: ESMF_6_3_0rp1
+
+requirements:
+  build:
+    - netcdf-fortran
+    - mpich2
+  run:
+    - netcdf-fortran
+    - mpich2
+
+about:
+  home: http://www.earthsystemmodeling.org/
+  license: The University of Illinois/NCSA Open Source License (NCSA)
+  summary: The Earth System Modeling Framework (ESMF) is software for building and coupling weather, climate, and related models.

--- a/esmpy/build.sh
+++ b/esmpy/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+
+export ESMFMKFILE=`find ${PREFIX} -name '*esmf.mk'`
+ESMPY_SRC=`find . -name '*ESMPy*'`
+cd ${ESMPY_SRC}
+${PYTHON} setup.py build --ESMFMKFILE=${ESMFMKFILE}
+${PYTHON} setup.py install --record record.txt
+${PYTHON} setup.py test || exit 1
+
+

--- a/esmpy/meta.yaml
+++ b/esmpy/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 requirements:
   build:
-    - python
+    - python >=2.7,<3
     - numpy
     - esmf ==6.3.0rp1
   run:

--- a/esmpy/meta.yaml
+++ b/esmpy/meta.yaml
@@ -1,0 +1,34 @@
+package:
+  name: esmpy
+  version: 6.3.0rp1
+
+build:
+  number: 0
+  skip: True # [osx]
+  skip: True # [win]
+  skip: True # [py3k]
+
+source:
+  git_url: git://git.code.sf.net/p/esmf/esmf
+  git_tag: ESMF_6_3_0rp1
+
+requirements:
+  build:
+    - python
+    - numpy
+    - esmf ==6.3.0rp1
+  run:
+    - python
+    - numpy
+    - esmf ==6.3.0rp1
+    - mpi4py
+
+# TODO (bekozi): Use run_test.sh with ESMPy 7 release.
+test:
+  imports:
+    - ESMF
+
+about:
+  home: https://www.earthsystemcog.org/projects/esmpy/
+  license: The University of Illinois/NCSA Open Source License (NCSA)
+  summary: ESMPy is a Python interface to the Earth System Modeling Framework (ESMF) regridding utility.


### PR DESCRIPTION
I tested the recipes using the ``continuumio/anaconda`` Docker image:

```sh
apt-get update
apt-get install git build-essential gfortran
conda build esmpy
```

Builds and ``ESMPy`` tests worked fine. I did not test on an external container. I went for very slim recipes. Let's see how it goes!

Of note: 
 * ``ESMPy v7`` will be coming out soonish causing changes to the testing. We can test externally for example.
 * It looks like conda folks are considering adding a ``--depth`` flag to ``git clone`` which would reduce the size of the ``ESMF`` repo: https://github.com/conda/conda/issues/1262.

Things to do before merge:
 - [ ] Enable ``ESMF`` testing. I think it makes sense to get the basic build and installation processes working. The tests take 20-30 minutes to run. ``ESMPy`` tests will run in a much shorter time. If ``ESMF`` tests are needed in addition to ``ESMPy`` tests is open for debate.
 
Watchers: @cdeluca, @rokuingh