### PR TITLE
Enforce Python 2.7

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: IOOS
 channels:
     - ioos
 dependencies:
+    - python=2.7
     - basemap
     - beautifulsoup4
     - cartopy


### PR DESCRIPTION
We are almost at a point where virtually all packages are available in Python 3.  So maybe it is good to enforce Python 2.7 in the `environment.yml` file to avoid undesirable upgrades.