### PR TITLE
Bump sci-wms metapackage

### DIFF
--- a/sci-wms/meta.yaml
+++ b/sci-wms/meta.yaml
@@ -1,6 +1,6 @@
 package:
     name: sci-wms
-    version: "1.3.0"
+    version: "1.4.0"
 
 build:
     number: 0


### PR DESCRIPTION
## 1.4.0 2015-11-19

[Bug] 107: Fix lat/lon order on UGRID datasets
[Bug] 105: Allow empty width/height parameters in GetLegendGraphic requests
[Feature] 101: Ability to view sci-wms logs from the web client (login only)
[Feature] 106: Support the COLORBARONLY parameter in GetLegendGraphic