### PR TITLE
Updated sparqlwrapper to 1.7.5

### DIFF
--- a/sparqlwrapper/meta.yaml
+++ b/sparqlwrapper/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: sparqlwrapper
-    version: "1.7.4"
+    version: "1.7.5"
 
 source:
-    fn: SPARQLWrapper-1.7.4.tar.gz
-    url: https://pypi.python.org/packages/source/S/SPARQLWrapper/SPARQLWrapper-1.7.4.tar.gz
-    md5: a235432b2bbf738acde8122f2fd3625e
+    fn: SPARQLWrapper-1.7.5.tar.gz
+    url: https://pypi.python.org/packages/source/S/SPARQLWrapper/SPARQLWrapper-1.7.5.tar.gz
+    md5: a7c0cf069c7b2185e8bf265d49c705a0
 
 build:
     number: 0


### PR DESCRIPTION
SPARQLWrapper's changelog:
-------------------------

2015-11-19  1.7.5   - Removed pip dependency on setup (issue 69)