### PR TITLE
Updated requests_toolbelt to 0.5.0

### DIFF
--- a/requests-toolbelt/meta.yaml
+++ b/requests-toolbelt/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: requests-toolbelt
-    version: "0.4.0"
+    version: "0.5.0"
 
 source:
-    fn: requests-toolbelt-0.4.0.tar.gz
-    url: https://pypi.python.org/packages/source/r/requests-toolbelt/requests-toolbelt-0.4.0.tar.gz
-    md5: 2278d650faadf181dd180682591e5926
+    fn: requests-toolbelt-0.5.0.tar.gz
+    url: https://pypi.python.org/packages/source/r/requests-toolbelt/requests-toolbelt-0.5.0.tar.gz
+    md5: 317a788caa4eec4e3b8f2433c646eaa8
 
 build:
     number: 0


### PR DESCRIPTION
```
History
=======

0.5.0 -- 2015-11-24
-------------------

More information about this release can be found on the `milestone
<https://github.com/sigmavirus24/requests-toolbelt/issues?utf8=%E2%9C%93&q=is%3Aall+milestone%3A0.5+>`_
for 0.5.0.

New Features

- The ``tee`` submodule was added to ``requests_toolbelt.downloadutils``. It
  allows you to iterate over the bytes of a response while also writing them
  to a file. The ``tee.tee`` function, expects you to pass an open file
  object, while ``tee.tee_to_file`` will use the provided file name to open
  the file for you.

- Added a new parameter to ``requests_toolbelt.utils.user_agent`` that allows
  the user to specify additional items.

- Added nested form-data helper,
  ``requests_toolbelt.utils.formdata.urlencode``.

- Added the ``ForgetfulCookieJar`` to ``requests_toolbelt.cookies``.

- Added utilities for dumping the information about a request-response cycle
  in ``requests_toolbelt.utils.dump``.

- Implemented the API described in the ``requests_toolbelt.threaded`` module
  docstring, i.e., added ``requests_toolbelt.threaded.map`` as an available
  function.

Fixed Bugs

- Now papers over the API differences in versions of requests installed from
  system packages versus versions of requests installed from PyPI.

- Allow string types for ``SourceAddressAdapter``.
```