### PR TITLE
Updated testfixtures to 4.5.1

### DIFF
--- a/testfixtures/meta.yaml
+++ b/testfixtures/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: testfixtures
-    version: "4.3.3"
+    version: "4.5.1"
 
 source:
-    fn: testfixtures-4.3.3.tar.gz
-    url: https://pypi.python.org/packages/source/t/testfixtures/testfixtures-4.3.3.tar.gz
-    md5: 89cf9193c8076043e59c921bb898382e
+    fn: testfixtures-4.5.1.tar.gz
+    url: https://pypi.python.org/packages/source/t/testfixtures/testfixtures-4.5.1.tar.gz
+    md5: b47f0db985dbcbb3668442fd91024732
 
 build:
     number: 0


### PR DESCRIPTION
```
Changes
=======

.. currentmodule:: testfixtures

4.5.1 (23 November 2015)
------------------------

- Switch from :class:`cStringIO` to :class:`StringIO` in :class:`OutputCapture`
  to better handle unicode being written to `stdout` or `stderr`.

Thanks to "tell-k" for the patch.

4.5.0 (13 November 2015)
------------------------

- :class:`LogCapture`, :class:`OutputCapture` and :class:`TempDirectory` now
  explicitly show what is expected versus actual when reporting differences.

Thanks to Daniel Fortunov for the pull request.

4.4.0 (1 November 2015)
-----------------------

- Add support for labelling the arguments passed to :func:`compare`.

- Allow ``expected`` and ``actual`` keyword parameters to be passed to
  :func:`compare`.

- Fix ``TypeError: unorderable types`` when :func:`compare` found multiple
  differences in sets and dictionaries on Python 3.

- Add official support for Python 3.5.

- Drop official support for Python 2.6.

Thanks to Daniel Fortunov for the initial ideas for explicit ``expected`` and
``actual`` support in :func:`compare`.
```