### PR TITLE
Updated numdifftools to 0.9.14

### DIFF
--- a/numdifftools/meta.yaml
+++ b/numdifftools/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: numdifftools
-    version: "0.9.13"
+    version: "0.9.14"
 
 source:
-    fn: numdifftools-0.9.13.zip
-    url: https://pypi.python.org/packages/source/N/Numdifftools/numdifftools-0.9.13.zip
-    md5: 86295fdf387780028ffc97eecdc9dce9
+    fn: numdifftools-0.9.14.zip
+    url: https://pypi.python.org/packages/source/N/Numdifftools/numdifftools-0.9.14.zip
+    md5: 04add9a62433466923764d9ef501eeb5
 
 build:
     skip: True  # [py35]


### PR DESCRIPTION
=========
Changelog
=========

Created with gitcommand: git shortlog v0.9.13..v0.9.14


Version 0.9.14, November 10, 2015
---------------------------------

pbrod (53):
      * Updated documentation of setup.py
      * Updated README.rst
      * updated version
      * Added more documentation
      * Updated example
      * Added .landscape.yml     updated .coveragerc, .travis.yml
      * Added coverageall to README.rst.
      * updated docs/index.rst
      * Removed unused code and added tests/test_extrapolation.py
      * updated tests
      * Added more tests
      * Readded c_abs c_atan2
      * Removed dependence on wheel, numpydoc>=0.5 and sphinx_rtd_theme>=0.1.7 (only needed for building documentation)
      * updated conda path in .travis.yml
      * added omnia channel to .travis.yml
      * Added conda_recipe files     Filtered out warnings in limits.py