### PR TITLE
Building development version of folium

### DIFF
--- a/folium/meta.yaml
+++ b/folium/meta.yaml
@@ -1,14 +1,13 @@
 package:
     name: folium
-    version: "0.1.6"
+    version: "0.2.0"
 
 source:
-    fn: folium-0.1.6.tar.gz
-    url: https://pypi.python.org/packages/source/f/folium/folium-0.1.6.tar.gz
-    md5: 96e76012d2517a376f2805a4860f8d1e
+    git_url: https://github.com/ocefpaf/folium.git
+    git_tag: simple_gjstyle
 
 build:
-    number: 2
+    number: 0
 
 requirements:
     build:


### PR DESCRIPTION
There is a significant change in the API in folium `v0.2.0` and this PR is to help people port their code.

Those who find their workflow broken due to the update must pin their folium version to `v0.1.6`.