### PR TITLE
Test netCDF4 build on Windows

### DIFF
--- a/netcdf4/bld.bat
+++ b/netcdf4/bld.bat
@@ -1,0 +1,12 @@
+set SITECFG=%SRC_DIR%/setup.cfg
+
+echo [options] > %SITECFG%
+echo use_cython=True >> %SITECFG%
+echo [directories] >> %SITECFG%
+echo HDF5_libdir = %LIBRARY_LIB% >> %SITECFG%
+echo HDF5_incdir = %LIBRARY_INC% >> %SITECFG%
+echo netCDF4_libdir = %LIBRARY_LIB% >> %SITECFG%
+echo netCDF4_incdir = %LIBRARY_INC% >> %SITECFG%
+
+"%PYTHON%" setup.py install --single-version-externally-managed  --record record.txt
+if errorlevel 1 exit 1

--- a/netcdf4/meta.yaml
+++ b/netcdf4/meta.yaml
@@ -8,7 +8,6 @@ source:
     md5: 9d9a7015ee98ec6766adc811d95b82c3
 
 build:
-    skip: True  # [win]
     number: 1
     entry_points:
         - ncinfo = netCDF4.utils:ncinfo
@@ -23,6 +22,7 @@ requirements:
         - cython
         - hdf5
         - libnetcdf
+        - mingwpy  # [win]
     run:
         - python
         - numpy x.x

--- a/netcdf4/meta.yaml
+++ b/netcdf4/meta.yaml
@@ -8,6 +8,7 @@ source:
     md5: 9d9a7015ee98ec6766adc811d95b82c3
 
 build:
+    skip: True  # [win and py35]
     number: 1
     entry_points:
         - ncinfo = netCDF4.utils:ncinfo

--- a/wera2netcdf/meta.yaml
+++ b/wera2netcdf/meta.yaml
@@ -8,6 +8,7 @@ source:
     md5: beb3bd457aebe6fa3d3b64cd2d0c0cbf
 
 build:
+    skip: True  # [win and py35]
     number: 0
 
 requirements:


### PR DESCRIPTION
~~Just testing.~~

The default channel is outdated (version 1.1.9 is two releases behind) and not build with Cython (so no `filepath` method).