### PR TITLE
Updated fortran-magic to 0.6.1

### DIFF
--- a/fortran-magic/meta.yaml
+++ b/fortran-magic/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: fortran-magic
-    version: "0.5.1"
+    version: "0.6.1"
 
 source:
-    fn: fortran-magic-0.5.1.tar.gz
-    url: https://pypi.python.org/packages/source/f/fortran-magic/fortran-magic-0.5.1.tar.gz
-    md5: dfcd7d23b0608537722059e3ff885513
+    fn: fortran-magic-0.6.1.tar.gz
+    url: https://pypi.python.org/packages/source/f/fortran-magic/fortran-magic-0.6.1.tar.gz
+    md5: 124f07838959516022305f5edce37a38
 
 build:
     number: 0


### PR DESCRIPTION
Changelog
=========

0.6 / 2015-12-02
----------------

- Decode text before printing
- Call f2py module instead of binary (numpy >=1.10 is mandatory)
- Check if f2py command failed

Thanks to `Juan Luis Cano Rodríguez`_ for this contribution

.. _Juan Luis Cano Rodriguez: https://github.com/Juanlu001