### PR TITLE
testfixtures 4.7.0

### DIFF
--- a/testfixtures/meta.yaml
+++ b/testfixtures/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: testfixtures
-    version: "4.5.1"
+    version: "4.7.0"
 
 source:
-    fn: testfixtures-4.5.1.tar.gz
-    url: https://pypi.python.org/packages/source/t/testfixtures/testfixtures-4.5.1.tar.gz
-    md5: b47f0db985dbcbb3668442fd91024732
+    fn: testfixtures-4.7.0.tar.gz
+    url: https://pypi.python.org/packages/source/t/testfixtures/testfixtures-4.7.0.tar.gz
+    md5: e892c81a6e223ff4a0cb301fe49b4ac0
 
 build:
     number: 0


### PR DESCRIPTION
Changes
=======

4.7.0 (10 December 2015)
------------------------

- Add the ability to pass ``raises=False`` to :func:`compare` to just get
  and resulting message back rather than having an exception raised.

4.6.0 (3 December 2015)
------------------------

- Fix a bug that mean symlinked directories would never show up when using
  :meth:`TempDirectory.compare` and friends.

- Add the ``followlinks`` parameter to :meth:`TempDirectory.compare` to
  indicate that symlinked or hard linked directories should be recursed into
  when using ``recursive=True``.