### PR TITLE
Updated setuptools_scm to 1.10.1

### DIFF
--- a/setuptools_scm/meta.yaml
+++ b/setuptools_scm/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: setuptools_scm
-    version: "1.9.0"
+    version: "1.10.1"
 
 source:
-    fn: setuptools_scm-1.9.0.tar.gz
-    url: https://pypi.python.org/packages/source/s/setuptools_scm/setuptools_scm-1.9.0.tar.gz
-    md5: 020e097756c4fd67a0f4518cac0ff190
+    fn: setuptools_scm-1.10.1.tar.bz2
+    url: https://pypi.python.org/packages/source/s/setuptools_scm/setuptools_scm-1.10.1.tar.bz2
+    md5: 99823e2cd564b996f18820a065f0a974
 
 build:
     number: 0


### PR DESCRIPTION
v1.10.1
=======

* fix issue 73 - in hg pre commit merge, consider parent1 instead of failing

v1.10.0
=======

* add support for overriding the version number via the 
  environment variable SETUPTOOLS_SCM_PRETEND_VERSION

* fix isssue 63 by adding the --match parameter to the git describe call
  and prepare the possibility of passing more options to scm backends

* fix issue 70 and 71 by introducing the parse keyword
  to specify custom scm parsing, its an expert feature,
  use with caution

  this change also introduces the setuptools_scm.parse_scm_fallback
  entrypoint which can be used to register custom archive fallbacks