### PR TITLE
pyscaffold 2.5

### DIFF
--- a/pyscaffold/meta.yaml
+++ b/pyscaffold/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: pyscaffold
-    version: "2.4.4"
+    version: "2.5"
 
 source:
-    fn: pyscaffold-2.4.4.tar.gz
-    url: https://pypi.python.org/packages/source/P/PyScaffold/pyscaffold-2.4.4.tar.gz
-    md5: 647ffe3bcd0454990e80aef291eea6ce
+    fn: PyScaffold-2.5.tar.gz
+    url: https://pypi.python.org/packages/source/P/PyScaffold/PyScaffold-2.5.tar.gz
+    md5: 546e2c74e30d2b47df53f22af9faa2a1
 
 build:
     number: 0


### PR DESCRIPTION
=============
Release Notes
=============

Version 2.5, 2015-12-09
=======================

- Usage of ``test-requirements.txt`` instead of ``tests_require`` in
  ``setup.py``, issue 71
- Removed ``--with-numpydoc`` flag since this is now included by default with
  ``spinx.ext.napoleon`` in Sphinx 1.3 and above
- Added small template for unittest
- Fix for the example skeleton file when using namespace packages
- Fix typo in devpi:upload section, issue 82
- Include ``pbr`` and ``setuptools_scm`` in PyScaffold to avoid dependency
  problems, issue 71 and 72
- Cool logo was designed by Eva Schmücker, issue 66