### PR TITLE
No mingwpy for netCDF4-python

### DIFF
--- a/netcdf4/meta.yaml
+++ b/netcdf4/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
     skip: True  # [win and py35]
-    number: 1
+    number: 2
     entry_points:
         - ncinfo = netCDF4.utils:ncinfo
         - nc4tonc3 = netCDF4.utils:nc4tonc3
@@ -23,7 +23,6 @@ requirements:
         - cython
         - hdf5
         - libnetcdf
-        - mingwpy  # [win]
     run:
         - python
         - numpy x.x


### PR DESCRIPTION
That was a left-over from my local build.