### PR TITLE
Re add rasterio

### DIFF
--- a/rasterio/bld.bat
+++ b/rasterio/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py build_ext -I"%LIBRARY_INC%" -lgdal_i -L"%LIBRARY_LIB%" install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/rasterio/build.sh
+++ b/rasterio/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py build_ext -I$PREFIX/include -L$PREFIX/lib -lgdal install --single-version-externally-managed --record record.txt

--- a/rasterio/meta.yaml
+++ b/rasterio/meta.yaml
@@ -1,0 +1,41 @@
+package:
+    name: rasterio
+    version: "0.30"
+
+source:
+    fn: rasterio-0.30.0.tar.gz
+    url: https://pypi.python.org/packages/source/r/rasterio/rasterio-0.30.0.tar.gz
+    md5: d20553b1531397c76925c2df1a5d53d6
+
+build:
+    number: 0
+    skip: True  # [win and py35 or osx]
+
+    entry_points:
+        - rio = rasterio.rio.main:cli
+
+requirements:
+    build:
+        - python
+        - numpy x.x
+        - cython
+        - gdal ==1.11.3
+        - setuptools
+    run:
+        - python
+        - affine
+        - cligj
+        - enum34  #  [py27]
+        - numpy x.x
+        - snuggs
+        - gdal ==1.11.3
+        - click-plugins
+
+test:
+    imports:
+        - rasterio
+
+about:
+    home: https://github.com/mapbox/rasterio
+    license: BSD
+    summary: 'Rasterio reads and writes geospatial raster datasets'

--- a/rasterio/run_test.py
+++ b/rasterio/run_test.py
@@ -1,0 +1,24 @@
+import numpy
+import rasterio
+from rasterio.features import rasterize
+from rasterio.transform import IDENTITY
+
+
+rows = cols = 10
+geometry = {'type': 'Polygon',
+            'coordinates': [[(2, 2), (2, 4.25), (4.25, 4.25),
+                             (4.25, 2), (2, 2)]]}
+
+with rasterio.drivers():
+    result = rasterize([geometry], out_shape=(rows, cols))
+    with rasterio.open(
+            "test.tif", 'w',
+            driver='GTiff',
+            width=cols,
+            height=rows,
+            count=1,
+            dtype=numpy.uint8,
+            nodata=0,
+            transform=IDENTITY,
+            crs={'init': "EPSG:4326"}) as out:
+        out.write_band(1, result.astype(numpy.uint8))


### PR DESCRIPTION
The default channel stopped updating `rasterio` at `0.25`.  See https://github.com/ioos/conda-recipes/pull/651#issue-122487200  also.