### PR TITLE
Fiona, rasterio, and geopandas for OSX+gdal 1.11.3.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
     - descartes
     - fiona
     - folium
-    - gdal<2
+    - gdal=1.11.3
     - geojson
     - geojsonio
     - geopandas

--- a/fiona/meta.yaml
+++ b/fiona/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
     number: 0
-    skip: True  # [win and py35 or osx]
+    skip: True  # [win and py35]
     preserve_egg_dir: True
     entry_points:
         - fio=fiona.fio.main:main_group

--- a/gdal/meta.yaml
+++ b/gdal/meta.yaml
@@ -13,6 +13,7 @@ source:
 
 build:
     number: 1
+    skip: True  # [win and py35]
 
 requirements:
     build:

--- a/rasterio/meta.yaml
+++ b/rasterio/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
     number: 0
-    skip: True  # [win and py35 or osx]
+    skip: True  # [win and py35]
 
     entry_points:
         - rio = rasterio.rio.main:cli


### PR DESCRIPTION
This PR should get OSX up to speed with Windows and Linux.