### PR TITLE
GeoPandas PY35 OSX

### DIFF
--- a/geopandas/meta.yaml
+++ b/geopandas/meta.yaml
@@ -8,7 +8,7 @@ source:
     md5: a01b5d3eb6bc097665a0ba297c39029f
 
 build:
-    skip: True  # [py35 and win or osx]
+    skip: True  # [py35 and win]
     number: 2
 
 requirements:
@@ -27,7 +27,7 @@ requirements:
         - rtree
         - descartes
         - matplotlib
-        - psycopg2  # [not py3k and not win]
+        - psycopg2  # [not win]
         - sqlalchemy
         - geopy ==1.10.0
         - pysal  # [not py3k]
@@ -41,6 +41,7 @@ test:
         - test.dbf
         - test.shp
         - test.shx
+
 about:
     home: http://geopandas.org
     license: BSD

--- a/geopy/meta.yaml
+++ b/geopy/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: geopy
-    version: "1.11.0"
+    version: "1.10.0"
 
 source:
-    fn: geopy-1.11.0.tar.gz
-    url: https://pypi.python.org/packages/source/g/geopy/geopy-1.11.0.tar.gz
-    md5: b73445dc0069550bbd2b09162f7339b3
+    fn: geopy-1.10.0.tar.gz
+    url: https://pypi.python.org/packages/source/g/geopy/geopy-1.10.0.tar.gz
+    md5: 57cab8fd885a88ad4acecc53346e4c39
 
 build:
     number: 0
@@ -21,9 +21,6 @@ test:
     imports:
         - geopy
         - geopy.geocoders
-    requires:
-        - mock
-        - pylint  # [not win64 and not py35]
 
 about:
     home: https://github.com/geopy/geopy


### PR DESCRIPTION
`geopandas` needs `geopy 1.10.0` and we did not have that for `PY35`.  I will revert `geopy` back to `1.11.0` after `geopandas` is uploaded. 