### PR TITLE
requests-toolbelt 0.5.1

### DIFF
--- a/requests-toolbelt/meta.yaml
+++ b/requests-toolbelt/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: requests-toolbelt
-    version: "0.5.0"
+    version: "0.5.1"
 
 source:
-    fn: requests-toolbelt-0.5.0.tar.gz
-    url: https://pypi.python.org/packages/source/r/requests-toolbelt/requests-toolbelt-0.5.0.tar.gz
-    md5: 317a788caa4eec4e3b8f2433c646eaa8
+    fn: requests-toolbelt-0.5.1.tar.gz
+    url: https://pypi.python.org/packages/source/r/requests-toolbelt/requests-toolbelt-0.5.1.tar.gz
+    md5: 580ab16edf9d1afad883623ba7873af9
 
 build:
     number: 0


### PR DESCRIPTION
# History

## 0.5.1 -- 2015-12-16

More information about this release can be found on the [0.5.1 milestone](https://github.com/sigmavirus24/requests-toolbelt/milestones/0.5.1)

### Fixed Bugs

- Now papers over the differences in requests' ``super_len`` function from
  versions prior to 2.9.0 and versions 2.9.0 and later.