### PR TITLE
Update yaml2ncml to 0.3.0

### DIFF
--- a/yaml2ncml/meta.yaml
+++ b/yaml2ncml/meta.yaml
@@ -1,10 +1,10 @@
 package:
     name: yaml2ncml
-    version: "0.2.0"
+    version: "0.3.0"
 
 source:
     git_url: https://github.com/usgs-cmg/yaml2ncml.git
-    git_tag: 0.2.0
+    git_tag: 0.3.0
 
 build:
     number: 0


### PR DESCRIPTION
This version turns on or off the "display" attribute based on included or excluded variables instead of removing them in the NcML. 