### PR TITLE
rasterio 0.31.0

### DIFF
--- a/rasterio/meta.yaml
+++ b/rasterio/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: rasterio
-    version: "0.30"
+    version: "0.31.0"
 
 source:
-    fn: rasterio-0.30.0.tar.gz
-    url: https://pypi.python.org/packages/source/r/rasterio/rasterio-0.30.0.tar.gz
-    md5: d20553b1531397c76925c2df1a5d53d6
+    fn: rasterio-0.31.0.tar.gz
+    url: https://pypi.python.org/packages/source/r/rasterio/rasterio-0.31.0.tar.gz
+    md5: 511e1418127c6d30b91e279154a4b4a4
 
 build:
     number: 0


### PR DESCRIPTION
```
Changes
=======

0.31.0 (2015-12-18)
-------------------
- Warn when rasters have no georeferencing and when the default identity
  transform will be applied by GDAL (524, 527).
- Build OS X wheels using numpy>=1.10.2 (529).
- When reading image windows in previous versions, given a window with
  ((row_start, row_stop), (col_start, col_stop)) if the stop index is greater
  than the width/height the start index effectively shifts as well. This can
  manifest itself in pixel misalignment if, e.g. you read block windows with
  a bit of padding to avoid edge effects. Now the window offsets are determined
  solely by row_start and col_start.(532, 533).
```