### PR TITLE
sparqlwrapper 1.7.6

### DIFF
--- a/sparqlwrapper/meta.yaml
+++ b/sparqlwrapper/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: sparqlwrapper
-    version: "1.7.5"
+    version: "1.7.6"
 
 source:
-    fn: SPARQLWrapper-1.7.5.tar.gz
-    url: https://pypi.python.org/packages/source/S/SPARQLWrapper/SPARQLWrapper-1.7.5.tar.gz
-    md5: a7c0cf069c7b2185e8bf265d49c705a0
+    fn: SPARQLWrapper-1.7.6.tar.gz
+    url: https://pypi.python.org/packages/source/S/SPARQLWrapper/SPARQLWrapper-1.7.6.tar.gz
+    md5: 3d3be71af7720caafa8fc970806e1cb6
 
 build:
     number: 0


### PR DESCRIPTION
```
2015-12-18  1.7.6   - Removed wrong response encoding (issue #70)
                    - Authorization header bug when using Python 3 (issue #71)
```