### PR TITLE
Fix some packaging issues with pyoos

### DIFF
--- a/pyoos/meta.yaml
+++ b/pyoos/meta.yaml
@@ -1,13 +1,14 @@
 package:
     name: pyoos
-    version: "0.6.2"
+    version: "0.7.0"
 
 source:
-    git_url: https://github.com/ocefpaf/pyoos.git
-    git_tag: fix_travis
+    fn : pyoos-0.7.0.tar.gz
+    url: https://pypi.python.org/packages/source/p/pyoos/pyoos-0.7.0.tar.gz
+    md5: bb79d03a57542bfa838c158765b949a8
 
 build:
-    number: 1
+    number: 0
     preserve_egg_dir: True
 
 requirements:
@@ -46,6 +47,6 @@ test:
         - pytest
 
 about:
-    home: https://github.com/asascience-open/pyoos
+    home: https://github.com/ioos/pyoos
     license: GNU General Public License v3 (GPLv3)
     summary: 'A Python library for collecting Met/Ocean observations'


### PR DESCRIPTION
# Pyoos 0.7.0

Version 0.7.0 is a pre-release version of Pyoos containing improved features, bug fixes and code clean ups.

## Features
- Conda package now available at anaconda ioos channel (@ocefpaf)
- Added a named project-level logger (@kwilcox)
- Added flatten_element utilities convenience function to return record-style time series representation by variable standard name (@emiliom)
- Improvements to collectors and parsers:
	- CO-OPS (added SML 1.0.1 Network Identifier XPath) (@lukecampbell)
	- IoosSweSos (improved robustness of variable/attribute detection and code clean-up in describe sensor metadata; TimeSeries bug fix) (@lukecampbell, @kwilcox)
	- HADS (improved parser handling of datetimes, values, and NaN flags; improved collector datetime filter) (@emiliom, @daf, @kwilcox)
	- NERRS (added optional, alternate mechanism for service access based on a NERRS-CDMO issued token; improved latitude & longitude parsing; added missing and corrected misspelled variable names and units) (@emiliom, @ocefpaf)

## Fixes
- TravisCI testing fixed for conda package (@daf, @ocefpaf)
- Fixed several tests (@kwilcox, @daf, @ocefpaf)
- Whitespace / PEP8 code cleanup (@kwilcox)
