### PR TITLE
fiona 1.6.3

### DIFF
--- a/fiona/meta.yaml
+++ b/fiona/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: fiona
-    version: "1.6.2"
+    version: "1.6.3"
 
 source:
-    fn: Fiona-1.6.2.tar.gz
-    url: https://pypi.python.org/packages/source/F/Fiona/Fiona-1.6.2.tar.gz
-    md5: 871674792aa53004c5af5c8bb45e399f
+    fn: Fiona-1.6.3.tar.gz
+    url: https://pypi.python.org/packages/source/F/Fiona/Fiona-1.6.3.tar.gz
+    md5: f6b70e1a30fc8db597c360e375d186de
 
 build:
     number: 0


### PR DESCRIPTION
1.6.3 (2015-12-22)
------------------
- Daytime has been decreasing in the Northern Hemisphere, but is now
  increasing again as it should.
- Non-UTF strings were being passed into OGR functions in some situations
  and on Windows this would sometimes crash a Python process (303). Fiona
  now raises errors derived from UnicodeError when field names or field
  values can't be encoded.