### PR TITLE
pyscaffold 2.5.2

### DIFF
--- a/pyscaffold/meta.yaml
+++ b/pyscaffold/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: pyscaffold
-    version: "2.5"
+    version: "2.5.2"
 
 source:
-    fn: PyScaffold-2.5.tar.gz
-    url: https://pypi.python.org/packages/source/P/PyScaffold/PyScaffold-2.5.tar.gz
-    md5: 546e2c74e30d2b47df53f22af9faa2a1
+    fn: PyScaffold-2.5.2.tar.gz
+    url: https://pypi.python.org/packages/source/P/PyScaffold/PyScaffold-2.5.2.tar.gz
+    md5: 2f20f32208188393b96bc92fe97e03bd
 
 build:
     number: 0


### PR DESCRIPTION
=============
Release Notes
=============

Version 2.5.2, 2016-01-02
=========================

- Fix ``is_git_installed``

Version 2.5.1, 2016-01-01
=========================

- Fix: Do some sanity checks first before gathering default options
- Updated setuptools_scm to version 1.10.0