### PR TITLE
Re-added msinttypes

### DIFF
--- a/msinttypes/meta.yaml
+++ b/msinttypes/meta.yaml
@@ -1,0 +1,7 @@
+# This is a placeholder meta, the canonical one comes from source.txt
+
+package:
+   name: msinttypes
+
+build:
+   script: exit 1

--- a/msinttypes/source.txt
+++ b/msinttypes/source.txt
@@ -1,0 +1,3 @@
+gh-repo: SciTools/conda-recipes-scitools
+git-tag: master
+contents: msinttypes/*


### PR DESCRIPTION
Somehow our binaries got corrupted on anaconda.org.  (See https://ci.appveyor.com/project/comtbot/conda-recipes/build/1.0.1739/job/w2ox0n0r1dj4ueye#L1927.)