### PR TITLE
use pip to install

### DIFF
--- a/oil_library/build.sh
+++ b/oil_library/build.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 
 pushd oil_library
-$PYTHON setup.py install  --single-version-externally-managed --record record.txt
+$PYTHON pip install ./
 popd
 
-# FIXME: Do we need a post-link.sh with:
-# pushd $RECIPE_DIR
-# $PYTHON setup.py remake_oil_db
-# popd


### PR DESCRIPTION
I like the pip command better -- certainly easier to remember. And I found the setup.py install method didn't work fo rme -- it couldn't find the source datafile to make the db. whereas pip did work.

As for:
```
# FIXME: Do we need a post-link.sh with:
# $PYTHON setup.py remake_oil_db
```
no -- that's not necessary -- the install should build the db fresh
 -- remake_oil_db is to force rebuilding the db if the source data has changed.