### PR TITLE
oct2py 3.4.0

### DIFF
--- a/oct2py/meta.yaml
+++ b/oct2py/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: oct2py
-    version: "3.3.3"
+    version: "3.4.0"
 
 source:
-    fn: oct2py-3.3.3.zip
-    url: https://pypi.python.org/packages/source/o/oct2py/oct2py-3.3.3.zip
-    md5: 3490c75455f2968b0da90a6e07d1b9a0
+    fn: oct2py-3.4.0.tar.gz
+    url: https://pypi.python.org/packages/source/o/oct2py/oct2py-3.4.0.tar.gz
+    md5: 010d527452abd78171bdf2575027daef
 
 build:
     number: 0
@@ -19,13 +19,12 @@ requirements:
         - numpy
         - scipy
         - ipython
+        #- octave
 
 test:
     imports:
-        - oct2py
-        - oct2py.tests
-        - oct2py.ipython
-        - oct2py.ipython.tests
+        #- oct2py
+        #- oct2py.ipython
 
 about:
     home: http://github.com/blink1073/oct2py


### PR DESCRIPTION
Release History
---------------

3.4.0 (2016-01-09)
++++++++++++++++++
- Improved handling of Octave executable
