### PR TITLE
Update siphon meta.yaml to new version

### DIFF
--- a/siphon/meta.yaml
+++ b/siphon/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: siphon
-    version: "0.3.1"
+    version: "0.3.2"
 
 source:
-    fn: siphon-0.3.1.tar.gz
-    url: https://pypi.python.org/packages/source/s/siphon/siphon-0.3.1.tar.gz
-    md5: 91c11e898107b87f44e5e3c6f1676dd2
+    fn: siphon-0.3.2.tar.gz
+    url: https://pypi.python.org/packages/source/s/siphon/siphon-0.3.2.tar.gz
+    md5: dd08ff89b1176939d59acae0d544dd81
 
 build:
     number: 0


### PR DESCRIPTION
Siphon 0.3.2 released Oct 30. https://github.com/Unidata/siphon/releases/tag/v0.3.2