### PR TITLE
httpretty 0.8.14

### DIFF
--- a/httpretty/meta.yaml
+++ b/httpretty/meta.yaml
@@ -1,14 +1,15 @@
 package:
     name: httpretty
-    version: "0.8.10"
+    version: "0.8.14"
 
 source:
-    fn: httpretty-0.8.10.tar.gz
-    url: https://pypi.python.org/packages/source/h/httpretty/httpretty-0.8.10.tar.gz
-    md5: 9c130b16726cbf85159574ae5761bce7
+    fn: httpretty-0.8.14.tar.gz
+    url: https://pypi.python.org/packages/source/h/httpretty/httpretty-0.8.14.tar.gz
+    md5: 2a6bbf270fafc77647b0479d95d0544c
 
 build:
     number: 0
+    skip: True  # [py3k]
 
 requirements:
     build:


### PR DESCRIPTION
# Release Notes

## 0.8.14 (current)

Improvements:

* Refactored `core.py` and increased its unit test coverage to 80%. HTTPretty is slightly more robust now.

Bug fixes:

* POST requests being called twice [#100](https://github.com/gabrielfalcao/HTTPretty/pull/100)