### PR TITLE
colander 1.2

### DIFF
--- a/colander/meta.yaml
+++ b/colander/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: colander
-    version: "1.0"
+    version: "1.2"
 
 source:
-    fn: colander-1.0.tar.gz
-    url: https://pypi.python.org/packages/source/c/colander/colander-1.0.tar.gz
-    md5: 058576123da7216288c079c9f47693f8
+    fn: colander-1.2.tar.gz
+    url: https://pypi.python.org/packages/source/c/colander/colander-1.2.tar.gz
+    md5: 83db21b07936a0726e588dae1914b9ed
 
 build:
     number: 0


### PR DESCRIPTION
1.2 (2016-01-18)
================

Features
--------

- Add new exception `UnsupportedFields`. Used to pass to the caller a list
  of extra fields detected in a cstruct during deserialize.
  See https://github.com/Pylons/colander/pull/241

- Add ``drop`` functionality to ``Sequence`` type.
  See https://github.com/Pylons/colander/pull/225

Bug Fixes
---------

- ``SchemaNode`` will no longer assume the first argument to the constructor
  is the schema type. This allows it to properly fallback to using the
  ``schema_type`` class attribute on subclasses even when using the
  imperative API to pass options to the constructor.

- Fix a bug in which ``MappingSchema``, ``SequenceSchema`` and
  ``TupleSchema`` would always treat the first arg as the schema type. This
  meant that it would fail if passed only nodes to the constructor despite
  the default type being implied by the name. It is now possible to do
  ``MappingSchema(child1, child2, ...)`` instead of
  ``MappingSchema(Mapping(), child1, child2)``.

Translations
------------

- Added Finnish translations: ``fi``
  See https://github.com/Pylons/colander/pull/243

1.1 (2016-01-15)
================

Platform
--------

- Add explicit support for Python 3.4, Python 3.5 and PyPy3.

Features
--------

- Add ``min_err`` and ``max_err`` arguments to ``Length``, allowing
  customization of its error messages.

- Add ``colander.Any`` validator: succeeds if at least one of its
  subvalidators succeeded.

- Allow localization of error messages returned by ``colander.Invalid.asdict``
  by adding an optional ``translate`` callable argument.

- Add a ``missing_msg`` argument to ``SchemaNode``, allowing customization
  of the error message used when the node is required and missing.

- Add `NoneOf` validator wich succeeds if the value is none of the choices.

- Add ``normalize`` option to ``Decimal``, stripping the rightmost
  trailing zeros.

Bug Fixes
---------

- Fix an issue where the ``flatten()`` method produces an invalid name
  (ex: "answer.0.") for the type ``Sequence``.  See
  https://github.com/Pylons/colander/issues/179

- Fixed issue with ``String`` not being properly encoded when non-string
  values were passed into ``serialize()``
  See `#235 <https://github.com/Pylons/colander/pull/235>`_

- ``title`` was being overwritten when made a child through defining a schema
  as a class. See https://github.com/Pylons/colander/pull/239

Translations
------------

- Added new translations: ``el``

- Updated translations: ``fr``, ``de``, ``ja``