### PR TITLE
requests-toolbelt 0.6.0

### DIFF
--- a/requests-toolbelt/meta.yaml
+++ b/requests-toolbelt/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: requests-toolbelt
-    version: "0.5.1"
+    version: "0.6.0"
 
 source:
-    fn: requests-toolbelt-0.5.1.tar.gz
-    url: https://pypi.python.org/packages/source/r/requests-toolbelt/requests-toolbelt-0.5.1.tar.gz
-    md5: 580ab16edf9d1afad883623ba7873af9
+    fn: requests-toolbelt-0.6.0.tar.gz
+    url: https://pypi.python.org/packages/source/r/requests-toolbelt/requests-toolbelt-0.6.0.tar.gz
+    md5: f7863ab5144a3ace64a4c851ec290907
 
 build:
     number: 0


### PR DESCRIPTION
```
History
=======

0.6.0 -- 2016-01-27
-------------------

More information about this release can be found on the `0.6.0 milestone`_.

New Features
~~~~~~~~~~~~

- Add ``AppEngineAdapter`` to support developers using Google's AppEngine
  platform with Requests.

- Add ``GuessProxyAuth`` class to support guessing between Basic and Digest
  Authentication for proxies.

Fixed Bugs
~~~~~~~~~~

- Ensure that proxies use the correct TLS version when using the
  ``SSLAdapter``.

- Fix an ``AttributeError`` when using the ``HTTPProxyDigestAuth`` class.

Miscellaneous
~~~~~~~~~~~~~

- Drop testing support for Python 3.2. virtualenv and pip have stopped
  supporting it meaning that it is harder to test for this with our CI
  infrastructure. Moving forward we will make a best-effort attempt to
  support 3.2 but will not test for it.


.. _0.6.0 milestone:
    https://github.com/sigmavirus24/requests-toolbelt/milestones/0.6.0
```