### PR TITLE
cyordereddict 1.0.0

### DIFF
--- a/cyordereddict/meta.yaml
+++ b/cyordereddict/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: cyordereddict
-    version: "0.2.2"
+    version: "1.0.0"
 
 source:
-    fn: cyordereddict-0.2.2.tar.gz
-    url: https://pypi.python.org/packages/source/c/cyordereddict/cyordereddict-0.2.2.tar.gz
-    md5: 6279eb0bf9819f0293ad5315b2d484d0
+    fn: cyordereddict-1.0.0.tar.gz
+    url: https://pypi.python.org/packages/source/c/cyordereddict/cyordereddict-1.0.0.tar.gz
+    md5: 8924331ec3bb754c92fd2603d3a29489
 
 build:
     number: 0


### PR DESCRIPTION
@shoyer not sure if you use the IOOS channel but pretty soon I will be moving `xray`\*, `dask`, `cyordereddict` and the rest of its dependencies to `conda-forge`.

\* To me it will always be `xray` :grin: