### PR TITLE
xarray 0.7.1

### DIFF
--- a/xarray/build.sh
+++ b/xarray/build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/xarray/meta.yaml
+++ b/xarray/meta.yaml
@@ -1,14 +1,15 @@
 package:
     name: xarray
-    version: "0.7.0"
+    version: "0.7.1"
 
 source:
-    fn: xarray-0.7.0.tar.gz
-    url: https://pypi.python.org/packages/source/x/xarray/xarray-0.7.0.tar.gz
-    md5: 4b5767ca330de3c05237c721d4589d54
+    fn: xarray-0.7.1.tar.gz
+    url: https://pypi.python.org/packages/source/x/xarray/xarray-0.7.1.tar.gz
+    md5: 22444bf16f9bd6d629385625df41e6b3
 
 build:
-    number: 2
+    script: python setup.py install --single-version-externally-managed --record record.txt
+    number: 0
 
 requirements:
     build:
@@ -37,3 +38,7 @@ about:
     home: https://github.com/pydata/xarray
     license: Apache Software License
     summary: 'N-D labeled arrays and datasets in Python'
+
+extra:
+    recipe-maintainers:
+        - ocefpaf


### PR DESCRIPTION
## v0.7.1 (16 February 2016)

This is a bug fix release that includes two small, backwards compatible enhancements.
We recommend that all users upgrade.

### Enhancements

- Numerical operations now return empty objects on no overlapping labels rather
  than raising ``ValueError`` (:issue:`739`).
- :py:class:`~pd.Series` is now supported as valid input to the ``Dataset``
  constructor (:issue:`740`).

### Bug fixes

- Restore checks for shape consistency between data and coordinates in the
  DataArray constructor (:issue:`758`).
- Single dimension variables no longer transpose as part of a broader
  ``.transpose``. This  behavior was causing ``pandas.PeriodIndex`` dimensions
  to lose their type (:issue:`749`)
- :py:class:`~xarray.Dataset` labels remain as their native type on ``.to_dataset``.
  Previously they were coerced to strings (:issue:`745`)
- Fixed a bug where replacing a ``DataArray`` index coordinate would improperly
  align the coordinate (:issue:`725`).
- ``DataArray.reindex_like`` now maintains the dtype of complex numbers when
  reindexing leads to NaN values (:issue:`738`).
- ``Dataset.rename`` and ``DataArray.rename`` support the old and new names
  being the same (:issue:`724`).
- Fix :py:meth:`~xarray.Dataset.from_dataset` for DataFrames with Categorical
  column and a MultiIndex index (:issue:`737`).
- Fixes to ensure xarray works properly after the upcoming pandas v0.18 and
  NumPy v1.11 releases.