### PR TITLE
simplejson 3.8.2

### DIFF
--- a/simplejson/build.sh
+++ b/simplejson/build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/simplejson/meta.yaml
+++ b/simplejson/meta.yaml
@@ -1,14 +1,15 @@
 package:
     name: simplejson
-    version: "3.8.0"
+    version: "3.8.2"
 
 source:
-    fn: simplejson-3.8.0.tar.gz
-    url: https://pypi.python.org/packages/source/s/simplejson/simplejson-3.8.0.tar.gz
-    md5: 72f3b93a6f9808df81535f79e79565a2
+    fn: simplejson-3.8.2.tar.gz
+    url: https://pypi.python.org/packages/source/s/simplejson/simplejson-3.8.2.tar.gz
+    md5: 53b1371bbf883b129a12d594a97e9a18
 
 build:
     number: 0
+    script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
     build:
@@ -27,3 +28,7 @@ about:
     home: http://github.com/simplejson/simplejson
     license: MIT License or Academic Free License (AFL)
     summary: 'Simple, fast, extensible JSON encoder/decoder for Python'
+
+extra:
+    recipe-maintainers:
+        - ocefpaf


### PR DESCRIPTION
Version 3.8.2 released 2016-02-14

* Fix implicit cast compiler warning in _speedups.c
* simplejson is now available as wheels for OS X and Windows thanks to Travis-CI
  and AppVeyor respectively! Many thanks to @aebrahim for getting this party
  started.
  https://github.com/simplejson/simplejson/pull/130
  https://github.com/simplejson/simplejson/issues/122

Version 3.8.1 released 2015-10-27

* Fix issue with iterable_as_array and indent option
  https://github.com/simplejson/simplejson/issues/128
* Fix typo in keyword argument name introduced in 3.8.0
  https://github.com/simplejson/simplejson/pull/123