### PR TITLE
eofs 1.0.0

### DIFF
--- a/eofs/build.sh
+++ b/eofs/build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/eofs/meta.yaml
+++ b/eofs/meta.yaml
@@ -1,14 +1,16 @@
 package:
     name: eofs
-    version: "0.5.1"
+    version: "1.0.0"
 
 source:
-    fn: eofs-0.5.1.tar.gz
-    url: https://pypi.python.org/packages/source/e/eofs/eofs-0.5.1.tar.gz
-    md5: c9256f04a02db12f256990e1e82be0bd
+    fn: eofs-1.0.0.tar.gz
+    url: https://pypi.python.org/packages/source/e/eofs/eofs-1.0.0.tar.gz
+    md5: e7ff7c5998379c4c6b0eda882e2de8b7
 
 build:
     number: 0
+    skip: True  # [py35]
+    script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
     build:
@@ -32,3 +34,7 @@ about:
     home: https://ajdawson.github.com/eofs
     license: GPL-3.0
     summary: 'EOF analysis in Python'
+
+extra:
+    recipe-maintainers:
+        - ocefpaf


### PR DESCRIPTION
## v1.0.x

### Release:	v1.0.0
### Date:	16 February 2016

- Allow arbitrary mode selection when reconstructing a field from EOFs.
- Auxiliary coordinates are now preserved in the eofs.iris and eofs.multivariate.iris interfaces.
- Improved documentation, including the addition of a developer guide.