### PR TITLE
Fix libgomp

### DIFF
--- a/cdo/meta.yaml
+++ b/cdo/meta.yaml
@@ -17,11 +17,13 @@ requirements:
         - libnetcdf
         - netcdf-fortran
         - proj.4
+        - gcc
     run:
         - jasper
         - libnetcdf
         - netcdf-fortran
         - proj.4
+        - libgcc
 
 test:
     commands:

--- a/nco/meta.yaml
+++ b/nco/meta.yaml
@@ -19,11 +19,13 @@ requirements:
         - hdf5
         - libnetcdf
         - udunits2
+        - gcc
     run:
         - gsl
         - hdf5
         - libnetcdf
         - udunits2
+        - libgcc
 
 test:
     commands:


### PR DESCRIPTION
I am not sure if this is the way to go.  Ping @daf and @bekozi who reported #723 and #700 respectively.

I tested using my docker image by uninstalling all the compiler and related system libraries and then built the packages with the default channel's `gcc`.  It worked locally, but I am not sure if it will work using our Docker image. (If not I am considering removing all the compiler from that image too and re-build everything using conda's gcc.)