### PR TITLE
uncertainties 2.4.8

### DIFF
--- a/uncertainties/build.sh
+++ b/uncertainties/build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/uncertainties/meta.yaml
+++ b/uncertainties/meta.yaml
@@ -1,13 +1,14 @@
 package:
     name: uncertainties
-    version: "2.4.7.1"
+    version: "2.4.8"
 
 source:
-    fn: uncertainties-2.4.7.1.tar.gz
-    url: https://pypi.python.org/packages/source/u/uncertainties/uncertainties-2.4.7.1.tar.gz
-    md5: e266ad2fba12799c6b7ff16841a7b83a
+    fn: uncertainties-2.4.8.tar.gz
+    url: https://pypi.python.org/packages/source/u/uncertainties/uncertainties-2.4.8.tar.gz
+    md5: d56374b66ae52146d463667a37d8c1cc
 
 build:
+    script: python setup.py install --single-version-externally-managed --record record.txt
     number: 0
 
 requirements:
@@ -32,3 +33,7 @@ about:
     home: http://pythonhosted.org/uncertainties/
     license: BSD License
     summary: 'Transparent calculations with uncertainties on the quantities involved (aka "error propagation"); fast calculation of derivatives'
+
+extra:
+    recipe-maintainers:
+        - ocefpaf


### PR DESCRIPTION
- 2.4.8: Friendlier completions in Python shells, etc.: internal functions should not appear anymore (for the user modules: uncertainties, uncertainties.umath and uncertainties.unumpy). Parsing the shorthand notation (e.g. 3.1(2)) now works with infinite values (e.g. -inf(inf)); this mirrors the ability to print such numbers with uncertainty. The Particle Data Group rounding rule is applied in more cases (e.g. printing 724.2±26.2 now gives 724±26). The shorthand+LaTeX formatting of numbers with an infinite nominal value is fixed. uncertainties.unumpy.matrix now uses .std_devs instead of .std_devs(), for consistency with floats with uncertainty (automatic conversion of code added to uncertainties.1to2).