### PR TITLE
pyresample 1.1.6

### DIFF
--- a/pyresample/build.sh
+++ b/pyresample/build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/pyresample/meta.yaml
+++ b/pyresample/meta.yaml
@@ -1,13 +1,14 @@
 package:
     name: pyresample
-    version: "1.1.4"
+    version: 1.1.6
 
 source:
-    fn: pyresample-1.1.4.tar.gz
-    url: https://pypi.python.org/packages/source/p/pyresample/pyresample-1.1.4.tar.gz
-    md5: 57900c8d290ea61cd4af7954274d9bba
+    fn: pyresample-1.1.6.tar.gz
+    url: https://pypi.python.org/packages/source/p/pyresample/pyresample-1.1.6.tar.gz
+    md5: 1f1b0cbf8a104b082ee742418d0bb07a
 
 build:
+    script: python setup.py install --single-version-externally-managed --record record.txt
     number: 0
 
 requirements:


### PR DESCRIPTION
Changelog
=========

1.1.6
-------

- Fix 35 supporting scipy kdtree again. [Martin Raspaud]

  A previous commit was looking for a 'data_pts' attribute in the kdtree
  object, which is available in pykdtree, but not scipy.

- Merge pull request 32 from mitkin/master. [Martin Raspaud]

  [tests] Skip deprecation warnings in test_gauss_multi_uncert

- Merge remote-tracking branch 'gh-pytroll/pre-master' [Mikhail Itkin]

- Put quotes around pip version specifiers to make things work. [Martin
  Raspaud]

- Install the right matplotlib in travis. [Martin Raspaud]

  The latest matplotlib (1.5) doesn't support python 2.6 and 3.3. This patch
  chooses the right matplotlib version to install depending on the python
  version at hand.

- Skip deprecation warnings. [Mikhail Itkin]

  Catch the rest of the warnings. Check if there is only one, and
  whether it contains the relevant message ('possible more than 8
  neighbours found'). This patch is necessary for python 2.7.9 and newer


- Merge pull request 31 from bhawkins/fix-kdtree-dtype. [Martin
  Raspaud]

  Fix possible type mismatch with pykdtree.

- Add test to expose pykdtree TypeError exception. [Brian Hawkins]

- Fix possible type mismatch with pykdtree. [Brian Hawkins]

- Update changelog. [Martin Raspaud]

- Bump version: 1.1.4 → 1.1.5. [Martin Raspaud]

- Don't build on 3.2 anymore (because of coverage's lack of support for
  3.2). [Martin Raspaud]

- Fix build badge adress. [Martin Raspaud]

- Fix the unicode problem in python3. [Martin Raspaud]

- Update changelog. [Martin Raspaud]

- Bump version: 1.1.3 → 1.1.4. [Martin Raspaud]

- Bugfix: Accept unicode proj4 strings. Fixes #24. [Martin Raspaud]

- Add python-configobj as a rpm requirement in setup.cfg. [Martin
  Raspaud]

- Add setup.cfg to allow rpm generation with bdist_rpm. [Martin Raspaud]

- Bugfix to address a numpy DeprecationWarning. [Martin Raspaud]

  Numpy won't take non-integer indices soon, so make index an int.