### PR TITLE
testfixtures 4.9.1

### DIFF
--- a/testfixtures/meta.yaml
+++ b/testfixtures/meta.yaml
@@ -1,11 +1,11 @@
 package:
     name: testfixtures
-    version: "4.8.0"
+    version: 4.9.1
 
 source:
-    fn: testfixtures-4.8.0.tar.gz
-    url: https://pypi.python.org/packages/source/t/testfixtures/testfixtures-4.8.0.tar.gz
-    md5: f3f558d1be89128e1c4bb4f940a56f7e
+    fn: testfixtures-4.9.1.tar.gz
+    url: https://pypi.python.org/packages/source/t/testfixtures/testfixtures-4.9.1.tar.gz
+    md5: 388c3382450d72b2871daaf6fb68271d
 
 build:
     script: python setup.py install --single-version-externally-managed --record record.txt
@@ -25,7 +25,7 @@ test:
 about:
     home: http://www.simplistix.co.uk/software/python/testfixtures
     license: MIT
-    summary: 'A collection of helpers and mock objects for unit tests and doc tests.'
+    summary: A collection of helpers and mock objects for unit tests and doc tests.
 
 extra:
     recipe-maintainers:


### PR DESCRIPTION
Changes
=======

4.9.1 (19 February 2016)
------------------------

- Fix for use with PyPy, broken since 4.8.0.

Thanks to Nicola Iarocci for the pull request to fix.

4.9.0 (18 February 2016)
------------------------

- Added the `suffix` parameter to :func:`compare` to allow failure messages
  to include some additional context.

- Update package metadata to indicate Python 3.5 compatibility.

Thanks for Felix Yan for the metadata patch.

Thanks to Wim Glenn for the suffix patch.