### PR TITLE
eofs v1.1.0

### DIFF
--- a/eofs/meta.yaml
+++ b/eofs/meta.yaml
@@ -1,15 +1,13 @@
 package:
     name: eofs
-    version: "1.0.0"
+    version: 1.1.0
 
 source:
-    fn: eofs-1.0.0.tar.gz
-    url: https://pypi.python.org/packages/source/e/eofs/eofs-1.0.0.tar.gz
-    md5: e7ff7c5998379c4c6b0eda882e2de8b7
+    git_url: https://github.com/ajdawson/eofs
+    git_tag: v1.1.0
 
 build:
     number: 0
-    skip: True  # [py35]
     script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:


### PR DESCRIPTION
Changelog
=========

Release notes:

- Added an xarray interface allowing use of `xarray.DataArray` objects with eofs.
- Fix bug in setting ddof in `eofs.tools.iris.covariance_map()`, previously it was always 1 regardless of the ddof keyword.
- Better Python 2 and 3 support without relying on 2to3.