### PR TITLE
Basemap

### DIFF
--- a/basemap/bld.bat
+++ b/basemap/bld.bat
@@ -1,0 +1,6 @@
+:: Ensure our geos will be used.
+set GEOS_DIR=%LIBRARY_PREFIX%
+rmdir %SRC_DIR%/geos-3.3.3 /s /q
+
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/basemap/build.sh
+++ b/basemap/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Ensure our geos will be used.
+rm -rf $SRC_DIR\geos-3.3.3
+export GEOS_DIR=$PREFIX
+
+$PYTHON setup.py install

--- a/basemap/meta.yaml
+++ b/basemap/meta.yaml
@@ -1,0 +1,34 @@
+package:
+    name: basemap
+    version: 1.0.8.dev
+
+source:
+  git_url: https://github.com/matplotlib/basemap.git
+  git_tag: master
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+        - numpy x.x
+        - geos >=3.4.2
+    run:
+        - python
+        - numpy x.x
+        - geos >=3.4.2
+        - matplotlib
+        - pyproj
+
+test:
+    imports:
+        - mpl_toolkits.basemap
+about:
+    home: http://matplotlib.org/basemap
+    license: GNU GPL
+    summary: Plot on map projections (with coastlines and political boundaries) using matplotlib
+
+extra:
+    recipe-maintainers:
+        - ocefpaf


### PR DESCRIPTION
We need a `basemap` that use the same `geos` (3.4.2) as `cartopy` to install both in one environment.