### PR TITLE
Remove gcc from windows build.

### DIFF
--- a/recipes/mocsy/meta.yaml
+++ b/recipes/mocsy/meta.yaml
@@ -19,11 +19,11 @@ requirements:
         - setuptools
         - mingwpy  # [win]
         - numpy x.x
-        - gcc
+        - gcc  # [not win]
     run:
         - python
         - numpy x.x
-        - libgcc
+        - libgcc  # [not win]
 
 test:
     imports:


### PR DESCRIPTION
This should fix `mocsy` builds on Windows.