### PR TITLE
Conda build downgrade was before obvci_install_conda_build_tools.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ install:
 
     - conda config --add channels ioos
     - conda install --yes --quiet --channel conda-forge obvious-ci conda-build-all
-    - conda install --yes conda-build=1.20.0
     - obvci_install_conda_build_tools.py
+    - conda install --yes conda-build=1.20.0
 
     - conda info
 


### PR DESCRIPTION
Conda build downgrade needs to be after `obvci_install_conda_build_tools.py` to avoid being upgraded.