### PR TITLE
Pin versions

### DIFF
--- a/recipes/libspatialite/meta.yaml
+++ b/recipes/libspatialite/meta.yaml
@@ -14,7 +14,7 @@ source:
         - skip_failing_test.patch  # [osx]
 
 build:
-    number: 1
+    number: 3
     skip: True  # [win]
 
 requirements:
@@ -23,7 +23,7 @@ requirements:
         - geos
         - proj.4
         - freexl
-        - zlib
+        - zlib 1.2*
         - libxml2
         - pkg-config
     run:
@@ -31,7 +31,7 @@ requirements:
         - geos
         - proj.4
         - freexl
-        - zlib
+        - zlib 1.2*
         - libxml2
         - libgcc
 

--- a/recipes/libxml2/meta.yaml
+++ b/recipes/libxml2/meta.yaml
@@ -10,7 +10,7 @@ source:
     md5: 59d281614c87d0c767134c55de20a8a9
 
 build:
-    number: 4
+    number: 5
     skip: True  # [win]
 
 requirements:
@@ -21,13 +21,13 @@ requirements:
         - pkg-config
         - icu
         - libiconv
-        - zlib
-        - xz
+        - zlib 1.2*
+        - xz 5.0.*  # [not win]
     run:
         - icu
         - libiconv
-        - zlib
-        - xz
+        - zlib 1.2*
+        - xz 5.0.*  # [not win]
 
 test:
     files:


### PR DESCRIPTION
Should fix the `gdal` failure on OS X.