### PR TITLE
Skip iris on OS X and Python 3

### DIFF
--- a/recipes/iris/meta.yaml
+++ b/recipes/iris/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
     number: 0
+    skip: True  # [osx and py3k]
 
 requirements:
     build:

--- a/recipes/snuggs/meta.yaml
+++ b/recipes/snuggs/meta.yaml
@@ -24,6 +24,8 @@ requirements:
         - pyparsing
 
 test:
+    requires:
+        - pytest
     imports:
         - snuggs
 


### PR DESCRIPTION
Iris does not build on OS X and Python 3.