### PR TITLE
Fix env file for conda-forge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: IOOS
 channels:
-    - ioos
     - conda-forge
 dependencies:
     - python=2.7
@@ -14,7 +13,7 @@ dependencies:
     - descartes
     - fiona
     - folium
-    - gdal==1.11.4
+    - gdal
     - geojson
     - geojsonio
     - geopandas
@@ -32,9 +31,7 @@ dependencies:
     - oct2py
     - owslib
     - paegan
-    - paegan-transport
     - pandas
-    - pip
     - proj.4
     - pygc
     - pyoos
@@ -43,7 +40,6 @@ dependencies:
     - pyugrid
     - qrcode
     - rasterio
-    - rdflib
     - requests
     - rtree
     - scikit-learn
@@ -52,7 +48,6 @@ dependencies:
     - shapely
     - statsmodels
     - sympy
-    - utilities
     - xlrd
     - xray
     - yaml


### PR DESCRIPTION
@rsignell-usgs I removed the `ioos` channel and tweaked it a little bit to get this env file to work.

I removed `utilities` and `rdflib` that do not exist in conda-forge. The former should disappear and the latter is just not packaged yet.  Then renaming issue was with `paegan-transport` refusing to install with the rest of the stack. I need to check what is the conflict as conda is not very helpful there. Meanwhile I just removed it.
