### PR TITLE
corrected proj.4 to proj4

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,7 @@ dependencies:
     - owslib
     - paegan
     - pandas
-    - proj.4
+    - proj4
     - pygc
     - pyoos
     - pyproj


### PR DESCRIPTION
This repository is deprecated in favor of the [conda-forge](https://conda-forge.github.io/) project and any PR opened here will not be merged.

All the recipes here live now in their own feedstock (individual repository) under the conda-forge project umbrela.
You can browse the list of existing feedstocks [here](https://conda-forge.github.io/feedstocks.html) and start contributing there.

For more information see: https://conda-forge.github.io/#contribute
